### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,10 @@ jobs:
           #   arch: amd64
           - os: macos-latest
             arch: arm64
+          - os: windows-latest
+            arch: amd64
+          # - os: windows-latest
+          #   arch: arm64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
- [x] Update to docker-py 6.0
- [ ] Docs and stuff
- [ ]  `test_demos`: The system cannot find the path specified: '/tmp/dipdup'  
- [ ] `test_custom_config` fails, no env