### PR TITLE
fix start up for event config

### DIFF
--- a/src/dipdup/config.py
+++ b/src/dipdup/config.py
@@ -1283,6 +1283,8 @@ class EventIndexConfig(IndexConfig):
         for handler_config in self.handlers:
             handler_config.initialize_callback_fn(package)
 
+            if isinstance(handler_config, EventHandlerConfig):
+                handler_config.initialize_event_type(package)
 
 ResolvedIndexConfigU = (
     OperationIndexConfig


### PR DESCRIPTION
It seems that the event initialization was missed between 6.4.0 and 6.5.5 dipdup version.

In my config I have the handler for events:
```
indexes:
  rarible_aggregator_tracker_events:
    kind: event
    datasource: tzkt
    handlers:
      - callback: on_rarible_aggregator_event
        contract: rarible_aggregator_tracker
        tag: aggregator_event
```

Without that fix I get following error:
```
------------------------
  Launching Indexer ...
------------------------
WARNING  dipdup.database      Decimal context precision has been updated: 28 -> 300
INFO     dipdup.tzkt          tzkt: hosted (ghostnet), protocol v6 (PtMumbai…FCjaH1)
INFO     dipdup               Initializing database schema
...
INFO     dipdup.cli           Unhandled exception caught, crashdump saved to `/tmp/dipdup/crashdumps/tmp0vsz0klt.json`
Traceback (most recent call last):
  File "/usr/local/bin/dipdup", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 1157, in __call__
    return anyio.run(self._main, main, args, kwargs, **opts)
  File "/usr/local/lib/python3.10/site-packages/anyio/_core/_eventloop.py", line 70, in run
    return asynclib.run(func, *args, **backend_options)
  File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 292, in run
    return native_run(wrapper(), debug=debug)
  File "/usr/local/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.10/site-packages/anyio/_backends/_asyncio.py", line 287, in wrapper
    return await func(*args)
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 1160, in _main
    return await main(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 1076, in main
    rv = await self.invoke(ctx)
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 1687, in invoke
    return await _process_result(await sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 1434, in invoke
    return await ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.10/site-packages/asyncclick/core.py", line 780, in invoke
    rv = await rv
  File "/usr/local/lib/python3.10/site-packages/dipdup/cli.py", line 66, in wrapper
    raise e
  File "/usr/local/lib/python3.10/site-packages/dipdup/cli.py", line 57, in wrapper
    await fn(ctx, *args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/dipdup/cli.py", line 205, in run
    await dipdup.run()
  File "/usr/local/lib/python3.10/site-packages/dipdup/dipdup.py", line 464, in run
    await gather(*tasks)
  File "/usr/local/lib/python3.10/site-packages/dipdup/dipdup.py", line 112, in run
    indexes_processed = await gather(*tasks)
  File "/usr/local/lib/python3.10/site-packages/dipdup/index.py", line 154, in process
    await self._synchronize(sync_level)
  File "/usr/local/lib/python3.10/site-packages/dipdup/indexes/event/index.py", line 71, in _synchronize
    await self._process_level_events(events, sync_level)
  File "/usr/local/lib/python3.10/site-packages/dipdup/indexes/event/index.py", line 89, in _process_level_events
    matched_handlers = match_events(self._config.handlers, events)
  File "/usr/local/lib/python3.10/site-packages/dipdup/indexes/event/matcher.py", line 75, in match_events
    arg = prepare_event_handler_args(handler_config, event)
  File "/usr/local/lib/python3.10/site-packages/dipdup/indexes/event/matcher.py", line 42, in prepare_event_handler_args
    type_ = handler_config.event_type_cls
  File "/usr/local/lib/python3.10/site-packages/dipdup/config.py", line 1215, in event_type_cls
    raise ConfigInitializationException
dipdup.exceptions.ConfigInitializationException
________________________________________________________________________________

An unexpected error has occurred! Most likely it's a framework bug.

Please, tell us about it: https://github.com/dipdup-io/dipdup/issues
2023-04-18T17:16:50.559340522+03:00
```