### PR TITLE
Do not store positions for blacklisted pools

### DIFF
--- a/dipdup.yml
+++ b/dipdup.yml
@@ -3,7 +3,7 @@ package: demo_uniswap
 
 database:
   kind: sqlite
-  path: /tmp/uniswap.sqlite
+  path: /tmp/uniswap2.sqlite
   immune_tables:
     - token
 
@@ -91,6 +91,6 @@ advanced:
   decimal_precision: 128  # 🙄
   profiler: basic
   # FIXME: Wipe with immune_tables leads to foreign key issues
-  unsafe_sqlite: true
+  unsafe_sqlite: false
   skip_version_check: true
   logging: verbose

--- a/src/demo_uniswap/handlers/pool/mint.py
+++ b/src/demo_uniswap/handlers/pool/mint.py
@@ -18,21 +18,17 @@ async def mint(
     pool = await models.Pool.cached_get_or_none(event.data.address)
     if not pool or pool.id in BLACKLISTED_POOLS:
         ctx.logger.debug('Pool.mint: skipping pool %s as it is blacklisted', event.data.address)
-        pending_position = {
-            'owner': to_normalized_address(event.payload.owner),
-            'pool_id': to_normalized_address(event.data.address),
-            'blacklisted': True,
-        }
-    else:
-        await pool_update(ctx, pool, event, PoolUpdateSign.MINT)
-        pending_position = {
-            'owner': to_normalized_address(event.payload.owner),
-            'pool_id': pool.id,
-            'token0_id': pool.token0_id,
-            'token1_id': pool.token1_id,
-            'tick_lower_id': f'{pool.id}#{event.payload.tickLower}',
-            'tick_upper_id': f'{pool.id}#{event.payload.tickUpper}',
-        }
-
+        return
+    
+    await pool_update(ctx, pool, event, PoolUpdateSign.MINT)
+    
+    pending_position = {
+        'owner': to_normalized_address(event.payload.owner),
+        'pool_id': pool.id,
+        'token0_id': pool.token0_id,
+        'token1_id': pool.token1_id,
+        'tick_lower_id': f'{pool.id}#{event.payload.tickLower}',
+        'tick_upper_id': f'{pool.id}#{event.payload.tickUpper}',
+    }
     position_idx = f'{event.data.level}.{event.data.transaction_index}.{int(event.data.log_index) + 1}'
     models_repo.save_pending_position(position_idx, pending_position)

--- a/src/demo_uniswap/handlers/position_manager/collect.py
+++ b/src/demo_uniswap/handlers/position_manager/collect.py
@@ -16,9 +16,9 @@ async def collect(
         ctx.logger.warning('Blacklisted level %d', event.data.level)
         return
 
-    position = await models.Position.get(id=event.payload.tokenId)
-    if position.blacklisted:
-        ctx.logger.warning('Blacklisted pool %s', position.pool_id)
+    position = await models.Position.get_or_none(id=event.payload.tokenId)
+    if position is None:
+        ctx.logger.warning('Skipping position %s (must be blacklisted pool)', event.payload.tokenId)
         return
 
     token0 = await models.Token.cached_get(position.token0_id)

--- a/src/demo_uniswap/handlers/position_manager/decrease_liquidity.py
+++ b/src/demo_uniswap/handlers/position_manager/decrease_liquidity.py
@@ -16,9 +16,9 @@ async def decrease_liquidity(
         ctx.logger.warning('Blacklisted level %d', event.data.level)
         return
 
-    position = await models.Position.get(id=event.payload.tokenId)
-    if position.blacklisted:
-        ctx.logger.warning('Blacklisted pool %s', position.pool_id)
+    position = await models.Position.get_or_none(id=event.payload.tokenId)
+    if position is None:
+        ctx.logger.warning('Skipping position %s (must be blacklisted pool)', event.payload.tokenId)
         return
 
     token0 = await models.Token.cached_get(position.token0_id)

--- a/src/demo_uniswap/handlers/position_manager/increase_liquidity.py
+++ b/src/demo_uniswap/handlers/position_manager/increase_liquidity.py
@@ -16,9 +16,9 @@ async def increase_liquidity(
         ctx.logger.warning('Blacklisted level %d', event.data.level)
         return
 
-    position = await models.Position.get(id=event.payload.tokenId)
-    if position.blacklisted:
-        ctx.logger.warning('Blacklisted pool %s', position.pool_id)
+    position = await models.Position.get_or_none(id=event.payload.tokenId)
+    if position is None:
+        ctx.logger.warning('Skipping position %s (must be blacklisted pool)', event.payload.tokenId)
         return
 
     # TODO: remove me

--- a/src/demo_uniswap/handlers/position_manager/transfer.py
+++ b/src/demo_uniswap/handlers/position_manager/transfer.py
@@ -16,7 +16,9 @@ async def transfer(
         idx = f'{event.data.level}.{event.data.transaction_index}.{event.data.log_index}'
         pending_position = models_repo.get_pending_position(idx)
         if pending_position is None:
-            raise ValueError(f'Failed to get pending position, tx {event.data.transaction_hash}')
+            ctx.logger.warning('Skipping position %s (must be blacklisted pool)', event.payload.tokenId)
+            return
+
         position = models.Position(id=event.payload.tokenId, **pending_position)
     else:
         position = await models.Position.get(id=event.payload.tokenId)


### PR DESCRIPTION
Might be an issue with nullable foreign keys in sqlite or in Tortoise in general.
Removed all checks and now we are assuming that if there's no position then it is for a reason.