### PR TITLE
Fixed `schema wipe` command crash due to `dipdup_meta` table being always immune

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 - cli: Fixed `config export --full` command showing original config.
 - cli: Keep the last 100 reports only.
+- cli: Fixed `schema wipe` command crash due to `dipdup_meta` table being always immune.
 - config: Don't create empty SentryConfig if DSN is not set.
 - context: Share internal state between context instances.
 - jobs: Don't add jobs before scheduler is started.

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -435,14 +435,17 @@ async def schema_wipe(ctx: click.Context, immune: bool, force: bool) -> None:
     models = f'{config.package}.models'
 
     # NOTE: Don't be confused by the name of `--immune` flag, we want to drop all tables if it's set.
-    immune_tables = set() if immune else config.database.immune_tables | {'dipdup_meta'}
+    immune_tables = set() if immune else config.database.immune_tables
 
-    if isinstance(config.database, SqliteDatabaseConfig) and immune_tables:
+    if isinstance(config.database, SqliteDatabaseConfig):
         message = 'Support for immune tables in SQLite is experimental and requires `advanced.unsafe_sqlite` flag set'
         if config.advanced.unsafe_sqlite:
+            immune_tables.add('dipdup_meta')
             _logger.warning(message)
-        else:
+        elif immune_tables:
             raise ConfigurationError(message)
+    else:
+        immune_tables.add('dipdup_meta')
 
     if not force:
         try:


### PR DESCRIPTION
Closes #791 