### PR TITLE
Do not consider config as oneshot if `tezos.tzkt.head` index is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog], and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+### Fixed
+
+- cli: Do not consider config as oneshot if `tezos.tzkt.head` index is present.
+
 ## [7.3.1] - 2024-01-29
 
 ### Fixed

--- a/src/dipdup/dipdup.py
+++ b/src/dipdup/dipdup.py
@@ -182,7 +182,7 @@ class IndexDispatcher:
         # NOTE: Run forever if at least one index has no upper bound.
         for index in self._indexes.values():
             if isinstance(index._config, TzktHeadIndexConfig):
-                continue
+                return False
             if not index._config.last_level:
                 return False
 


### PR DESCRIPTION
Likely closes #934 