### PR TITLE
Fix: database migrations (follow up for #1110)

### DIFF
--- a/docs/1.getting-started/5.database.md
+++ b/docs/1.getting-started/5.database.md
@@ -130,7 +130,12 @@ For more information visit the official TimescaleDB documentation:
 DipDup supports database migrations leveraging Tortoise ORM migration package, `aerich`.
 The migration files are stored in the `migrations` directory in the project root.
 
-!! Note that database migrations feature is optional and is disabled by default. To enable it, you need to install `aerich` which is available in the `[migrations]` optional dependencies group
+!!! Note
+    The database migrations feature is optional and is disabled by default. To enable it, you need to install `aerich`, which is available in the `[migrations]` optional dependencies group.
+
+!!! Warning
+    - **Migrations are not supported in SQLite.**
+    - **Migrations are not supported if you use multiple databases in the same project.**
 
 DipDup provides a set of commands to manage databasek migrations:
 

--- a/docs/16.thanks.md
+++ b/docs/16.thanks.md
@@ -45,5 +45,6 @@ We are grateful to all the people who helped us with the project.
 - [Simon Bihel](https://github.com/sbihel)
 - [Soham Das](https://github.com/tosoham)
 - [tomsib2001](https://github.com/tomsib2001)
+- [bigherc18](https://github.com/bigherc18)
 
 If we forgot to mention you, or you want to update your record, please, open an issue or pull request.

--- a/pdm.lock
+++ b/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "docs", "lint", "migrations", "perf", "test"]
 strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
-content_hash = "sha256:bf4dcd81d5e13eba28aa0995cd81cb2478181a02a720a2dcd4308272af7d847a"
+content_hash = "sha256:7f4333f669cfe9240e257bef6afabd34b58ce39354dc611b6c74a4838ac66f85"
 
 [[metadata.targets]]
 requires_python = ">=3.12,<3.13"

--- a/src/dipdup/aerich.py
+++ b/src/dipdup/aerich.py
@@ -5,7 +5,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from types import ModuleType
 
-    from aerich import Command as AerichCommand
+    from aerich import Command as AerichCommand  # type: ignore[import-untyped]
 
 
 async def create_aerich_command(db_url: str, package: str, migrations_dir: 'Path') -> 'AerichCommand':
@@ -17,7 +17,7 @@ async def create_aerich_command(db_url: str, package: str, migrations_dir: 'Path
     from tortoise.backends.base.config_generator import generate_config
 
     # TODO: Refactor building the app_modules dict and use here and in the tortoise_wrapper function ?
-    # Or maybe add the tortoise_config to config ?
+    # Or maybe add the tortoise_config to database config ?
     app_modules: dict[str, Iterable[str | ModuleType]] = {'models': [f'{package}.models', 'aerich.models']}
     tortoise_config = generate_config(db_url=db_url, app_modules=app_modules)
     return AerichCommand(tortoise_config=tortoise_config, app='models', location=migrations_dir.as_posix())

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -764,12 +764,14 @@ async def schema_wipe(ctx: click.Context, immune: bool, force: bool) -> None:
     if isinstance(config.database, SqliteDatabaseConfig):
         message = 'Support for immune tables in SQLite is experimental and requires `advanced.unsafe_sqlite` flag set'
         if config.advanced.unsafe_sqlite:
-            immune_tables.add('dipdup_meta')
+            # FIXME: Define a global constant or config option for "always immune tables"
+            immune_tables = immune_tables | {'dipdup_meta', 'aerich'}
             _logger.warning(message)
         elif immune_tables:
             raise ConfigurationError(message)
     else:
-        immune_tables.add('dipdup_meta')
+        # FIXME: Define a global constant or config option for "always immune tables"
+        immune_tables = immune_tables | {'dipdup_meta', 'aerich'}
 
     if not force:
         try:

--- a/src/dipdup/cli.py
+++ b/src/dipdup/cli.py
@@ -650,6 +650,13 @@ async def schema(ctx: click.Context) -> None:
     config: DipDupConfig = ctx.obj.config
 
     if ctx.invoked_subcommand in AERICH_CMDS:
+        from dipdup.config import SqliteDatabaseConfig
+
+        if isinstance(config.database, SqliteDatabaseConfig):
+            from dipdup.exceptions import UnsupportedFeatureError
+
+            raise UnsupportedFeatureError('Database migrations are not supported for SQLite')
+
         from dipdup.package import DipDupPackage
 
         migrations_dir = DipDupPackage(config.package_path).migrations
@@ -689,7 +696,7 @@ def _approve_schema_after(command: click.Command) -> click.Command:
 
 
 try:
-    from aerich.cli import cli as aerich_cli
+    from aerich.cli import cli as aerich_cli  # type: ignore[import-untyped]
 
     schema.add_command(aerich_cli.commands['history'])
     schema.add_command(aerich_cli.commands['heads'])

--- a/src/dipdup/context.py
+++ b/src/dipdup/context.py
@@ -225,7 +225,8 @@ class DipDupContext:
 
         elif action == ReindexingAction.wipe:
             conn = get_connection()
-            immune_tables = self.config.database.immune_tables | {'dipdup_meta'}
+            # FIXME: Define a global var or config option for "always immune tables"
+            immune_tables = self.config.database.immune_tables | {'dipdup_meta', 'aerich'}
             await wipe_schema(
                 conn=conn,
                 schema_name=self.config.database.schema_name,

--- a/src/dipdup/dipdup.py
+++ b/src/dipdup/dipdup.py
@@ -29,6 +29,7 @@ from dipdup.config import SYSTEM_HOOKS
 from dipdup.config import DipDupConfig
 from dipdup.config import IndexTemplateConfig
 from dipdup.config import PostgresDatabaseConfig
+from dipdup.config import SqliteDatabaseConfig
 from dipdup.config.evm import EvmContractConfig
 from dipdup.config.starknet import StarknetContractConfig
 from dipdup.config.tezos import TezosContractConfig
@@ -728,7 +729,6 @@ class DipDup:
             self._schema = await Schema.get_or_none(name=schema_name)
 
         # NOTE: Call with existing Schema too to create new tables if missing
-        # TODO: Check if it doesn't conflict with aerich migrations
         try:
             await generate_schema(
                 conn,
@@ -743,7 +743,6 @@ class DipDup:
 
         schema_hash = get_schema_hash(conn)
 
-        # TODO: Advise to run `dipdup schema migrate` before `dipdup schema approve`
         if self._schema is None:
             await self._ctx.fire_hook('on_reindex')
 
@@ -926,6 +925,10 @@ class DipDup:
 
     async def _initialize_migrations(self) -> None:
         """Initialize database migrations with aerich."""
+        if isinstance(self._config.database, SqliteDatabaseConfig):
+            _logger.debug('SQLite database detected, skipping migrations initialization')
+            return
+
         migrations_dir = self._ctx.package.migrations
         try:
             aerich_command = await create_aerich_command(

--- a/src/dipdup/exceptions.py
+++ b/src/dipdup/exceptions.py
@@ -166,6 +166,7 @@ class ReindexingRequiredError(Error):
         if context:
             context = f'{prefix}{context}\n'
 
+        # TODO: If migrations are enabled, suggest `migrate` and `upgrade` instead of `approve`/`wipe`
         return f"""
             Reindexing required! Reason: {self.reason.value}.
               {context}
@@ -357,3 +358,13 @@ class UnsupportedAPIError(Error):
 # TODO: Human-readable Error
 class MigrationError(FrameworkException):
     pass
+
+
+@dataclass(repr=False)
+class UnsupportedFeatureError(Error):
+    """User trying to use an unsupported feature"""
+
+    msg: str
+
+    def _help(self) -> str:
+        return self.msg

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -18,6 +18,7 @@ _dipdup_tables = {
     'dipdup_head',
     'dipdup_index',
     'dipdup_meta',
+    'aerich',
 }
 
 
@@ -151,7 +152,7 @@ async def test_schema_postgres() -> None:
 
         async with tortoise():
             conn = get_connection()
-            assert await get_tables() == {'dipdup_meta'}
+            assert await get_tables() == {'dipdup_meta', 'aerich'}
 
 
 async def test_schema_postgres_immune() -> None:
@@ -192,4 +193,4 @@ async def test_schema_postgres_immune() -> None:
 
         async with tortoise():
             conn = get_connection()
-            assert await get_tables() == {'dipdup_meta', 'test', 'domain', 'tld'}
+            assert await get_tables() == {'dipdup_meta', 'aerich', 'test', 'domain', 'tld'}


### PR DESCRIPTION
This PR is a Follow up for #1110 adressing issue #1107 

Here's a lit of what have been done:

- Don't remove migrations dir on schema wipe
- Make `aerich` table immune to schema wipe
- Better documentation for database migrations
- Fix `mypy` errors
- Make database migrations not supported for SQLite