### PR TITLE
[Fix] Allow starknet contract addresses starting with '0x0'

### DIFF
--- a/src/dipdup/config/starknet.py
+++ b/src/dipdup/config/starknet.py
@@ -42,14 +42,11 @@ def _validate_starknet_address(v: str) -> str:
     # 
     # Convert hex to decimal and check if it's less than 2**251
     numeric_value = int(v, 16)
-    if not (numeric_value < 2**251):
-        raise ValueError(f'{v} exceeds Starkent address range [0...2**251]')
-
-    value = hex(numeric_value)
-    if not _TRUNCATED_STARKNET_ADDRESS_REGEXP.fullmatch(value):
+    truncated_value = hex(numeric_value)
+    if not _TRUNCATED_STARKNET_ADDRESS_REGEXP.fullmatch(truncated_value):
         raise ValueError(f'{v} is not a valid Starknet contract address')
 
-    return value
+    return truncated_value
 
 
 type StarknetAddress = Annotated[Hex, AfterValidator(_validate_starknet_address)]

--- a/src/dipdup/config/starknet.py
+++ b/src/dipdup/config/starknet.py
@@ -22,6 +22,8 @@ StarknetDatasourceConfigU: TypeAlias = StarknetSubsquidDatasourceConfig | Starkn
 
 _HEX_ADDRESS_REGEXP = re.compile(r'(0x)?[0-9a-f]{1,64}', re.IGNORECASE | re.ASCII)
 
+# Spec: https://github.com/starkware-libs/starknet-specs/blob/master/api/starknet_api_openrpc.json
+_TRUNCATED_STARKNET_ADDRESS_REGEXP = re.compile(r'^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$', re.ASCII)
 
 def _validate_starknet_address(v: str) -> str:
     """
@@ -32,15 +34,22 @@ def _validate_starknet_address(v: str) -> str:
         return v
 
     if _HEX_ADDRESS_REGEXP.fullmatch(v) is None:
-        raise ValueError(f'{v} is not a valid Starknet contract address')
+        raise ValueError(f'{v} is not a valid contract address (check if it is a hex string in the form 0x[64 hex chars])')
 
+    # Following code is similar to: 
+    #   https://github.com/software-mansion/starknet.py/blob/a8d73538d409d9ef7c756921e43d10925f2838bc/starknet_py/net/client_utils.py#L60
+    #   starknet_py.net.client_utils._to_rpc_felt method
+    # 
     # Convert hex to decimal and check if it's less than 2**251
     numeric_value = int(v, 16)
     if not (numeric_value < 2**251):
+        raise ValueError(f'{v} exceeds Starkent address range [0...2**251]')
+
+    value = hex(numeric_value)
+    if not _TRUNCATED_STARKNET_ADDRESS_REGEXP.fullmatch(value):
         raise ValueError(f'{v} is not a valid Starknet contract address')
 
-    # TODO: Probably needs to be to normalized as in EVM case
-    return v
+    return value
 
 
 type StarknetAddress = Annotated[Hex, AfterValidator(_validate_starknet_address)]

--- a/src/dipdup/indexes/starknet_events/matcher.py
+++ b/src/dipdup/indexes/starknet_events/matcher.py
@@ -1,7 +1,7 @@
 import logging
 from collections import deque
 from collections.abc import Iterable
-from typing import Any, Union
+from typing import Any
 
 from starknet_py.serialization._context import DeserializationContext  # type: ignore
 from starknet_py.serialization.data_serializers._common import deserialize_to_dict  # type: ignore
@@ -14,27 +14,10 @@ from dipdup.utils import parse_object
 from dipdup.utils import pascal_to_snake
 from dipdup.utils import snake_to_pascal
 
-
 _logger = logging.getLogger(__name__)
 
 MatchedEventsT = tuple[StarknetEventsHandlerConfig, StarknetEvent[Any]]
 
-
-def truncate_address_padding(address: Union[str, None]) -> Union[str, None]:
-    if address is None:
-        return None
-    
-    if isinstance(value, str):
-        try:
-            value = int(value, 16)
-        except ValueError:
-            _logger.debug(
-                'Can not truncate incorrect address %s', 
-                value
-            )
-            return None
-
-    return hex(value)
 
 def match_events(
     package: DipDupPackage,
@@ -60,12 +43,8 @@ def match_events(
             continue
 
         for handler_config, identifier, address in matching_data:
-            if address:              
-                truncated_address = truncate_address_padding(address)
-                truncated_event_from = truncate_address_padding(event.from_address)
-                if truncated_address != truncated_event_from:
-                    continue
-            
+            if address and address != event.from_address:
+                continue
             if identifier != event.keys[0]:
                 continue
 

--- a/tests/configs/demo_starknet_events.yml
+++ b/tests/configs/demo_starknet_events.yml
@@ -7,7 +7,7 @@ datasources:
     url: https://v2.archive.subsquid.io/network/starknet-mainnet
   node:
     kind: starknet.node
-    url: https://starknet-mainnet.g.alchemy.com/v2
+    url: https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/
 
 contracts:
   stark_usdt:


### PR DESCRIPTION
- [x] Added function to truncate addresses during matching so that 0x0 addresses could be matched correctly. 
- [x] Small fix in starknet demo config

Fixes #1141