### PR TITLE
Handle Starknet events keys/data correctly

### DIFF
--- a/src/dipdup/codegen/evm.py
+++ b/src/dipdup/codegen/evm.py
@@ -71,10 +71,7 @@ class EvmCodeGenerator(CodeGenerator):
         contracts_from_transactions: list[EvmContractConfig] = [
             handler_config.typed_contract
             for handler_config in index_config.handlers
-            if (
-                isinstance(handler_config, EvmTransactionsHandlerConfig)
-                and handler_config.typed_contract is not None
-            )
+            if (isinstance(handler_config, EvmTransactionsHandlerConfig) and handler_config.typed_contract is not None)
         ]
         contracts: Iterable[EvmContractConfig] = chain(contracts_from_event_handlers, contracts_from_transactions)
 


### PR DESCRIPTION
Finalizes changes in #1142 

- Fixed typehints
- Supported as many types as possible

Tested using:

```cairo

#[derive(Serde, PartialEq, Debug, Drop)]
pub(crate) struct Nested {
    pub f1: u8,
}

#[derive(Serde, PartialEq, Debug, Drop)]
pub(crate) enum FEnum {
    F1, F2, F3
}

#[derive(Serde, PartialEq, Debug, Drop)]
pub(crate) enum FEnumComplex {
    F1: (u8, u8), 
    F2: felt252, 
    F3: ()
}

#[derive(starknet::Event, PartialEq, Debug, Drop)]
pub(crate) struct E {
    pub(crate) v1: u8,
    pub(crate) v2: u16,
    pub(crate) v3: u32,
    pub(crate) v4: u64,
    pub(crate) v5: u128,
    pub(crate) v6: u256,
    pub(crate) v7: felt252,
    pub(crate) v8: Span<felt252>,
    pub(crate) v9: Span<Span<felt252>>,
    pub(crate) v10: Option<u8>,
    pub(crate) v11: Nested,
    pub(crate) v12: Span<Nested>,
    pub(crate) v13: Option<Nested>,
    pub(crate) v14: FEnum,
    pub(crate) v15: (),
    pub(crate) v16: bool,
    pub(crate) v17: (bool, u8),
    pub(crate) v18: FEnumComplex,
}
```

Important: Enums are translated into string sets of enum keys, internal types are erased.

ABI: [abi.json](https://gist.github.com/baitcode/da4b25a544ab15f0dd6737b7fba63a49#file-abi-json)
Json Schema: [here](https://gist.github.com/baitcode/da4b25a544ab15f0dd6737b7fba63a49#file-e-json)
Python Generated: [here](https://gist.github.com/baitcode/da4b25a544ab15f0dd6737b7fba63a49#file-e-py)
