### PR TITLE
Use EvmNode http config batch_size

### DIFF
--- a/src/dipdup/indexes/evm_events/fetcher.py
+++ b/src/dipdup/indexes/evm_events/fetcher.py
@@ -66,7 +66,7 @@ class EvmNodeEventFetcher(EvmNodeFetcher[EvmEventData]):
 
         while batch_first_level <= self._last_level:
             node = self.random_datasource
-            batch_size = self.get_next_batch_size(batch_size, ratelimited)
+            batch_size = node._http_config.batch_size or self.get_next_batch_size(batch_size, ratelimited)
             ratelimited = False
 
             started = time.time()


### PR DESCRIPTION
I noticed that the `HttpConfig.batch_size` option in the configuration ([docs](https://dipdup.io/docs/references/config#dipdupconfighttpconfig)) was not being applied in `EvmNodeEventFetcher`.

I attempted to fix this by implementing a similar approach to the one used [here](https://github.com/dipdup-io/dipdup/blob/next/src/dipdup/indexes/substrate_events/fetcher.py#L69). However, I'm not entirely sure if I made the changes in the correct place or if this is the best way to address the issue.

> [!NOTE] 
> I haven't run the integration tests, so I'm not certain if this change impacts anything else.

Please let me know if I need to adjust anything.