### PR TITLE
Setting Hasura documentation from the Tortoise model

### DIFF
--- a/src/dipdup/hasura.py
+++ b/src/dipdup/hasura.py
@@ -1,4 +1,5 @@
 import hashlib
+import inspect
 import logging
 import re
 from collections.abc import Iterable
@@ -192,6 +193,22 @@ class HasuraGateway(HTTPGateway):
         await self._replace_metadata(metadata)
 
         await self._apply_custom_metadata()
+
+        # Apply model docstrings as database comments
+        await self._apply_model_comments()
+
+        # Force metadata refresh to pick up new database comments
+        self._logger.info('Refreshing Hasura metadata to pick up new database comments')
+        await self._hasura_request(
+            endpoint='metadata',
+            json={
+                'type': 'reload_metadata',
+                'args': {
+                    'reload_remote_schemas': True,
+                    'recreate_event_triggers': True,
+                },
+            },
+        )
 
         # TODO: Find out why it is necessary
         # NOTE: Fetch metadata once again and save its hash for future comparisons
@@ -698,3 +715,122 @@ class HasuraGateway(HTTPGateway):
     def _iterate_metadata_requests(self) -> Iterator[TextIO]:
         metadata_path = env.get_package_path(self._package) / 'hasura'
         yield from iter_files(metadata_path, '.json')
+
+    async def _apply_model_comments(self) -> None:
+        """Extract docstrings from Tortoise models and apply them as database comments.
+
+        This method scans all models in the project and extracts their docstrings,
+        then applies them as SQL comments to the corresponding database tables and columns.
+        These comments will be visible in Hasura's GraphQL playground.
+        """
+        self._logger.info('Extracting model docstrings and applying database comments')
+
+        # Get database connection
+        conn = get_connection()
+        if not isinstance(conn, AsyncpgClient):
+            self._logger.warning('Model comments only supported for PostgreSQL databases')
+            return
+
+        # Debug: Log the package being processed
+        self._logger.info(f'Processing package: {self._package}')
+
+        # Iterate through all models
+        model_count = 0
+        for app_name, model_class in iter_models(self._package):
+            model_count += 1
+            self._logger.info(f'Processing model {model_count}: {model_class.__name__} from {app_name}')
+
+            if not hasattr(model_class, '_meta') or not hasattr(model_class._meta, 'db_table'):
+                self._logger.warning(f'Model {model_class.__name__} missing _meta or db_table')
+                continue
+
+            table_name = model_class._meta.db_table
+            self._logger.info(f'Table name: {table_name}')
+
+            # Extract table-level docstring
+            table_doc = model_class.__doc__ or ''
+            if table_doc:
+                # Clean up the docstring
+                table_doc = table_doc.strip().replace("'", "''")  # Escape single quotes
+                if len(table_doc) > 1000:  # Limit comment length
+                    table_doc = table_doc[:997] + '...'
+
+                # Apply table comment
+                try:
+                    sql = f"COMMENT ON TABLE {self._database_config.schema_name}.{table_name} IS '{table_doc}';"
+                    self._logger.info(f'Executing table comment SQL: {sql}')
+                    await conn.execute_script(sql)
+                    self._logger.info(f'Successfully applied table comment to {table_name}')
+                except Exception as e:
+                    self._logger.warning(f'Failed to apply table comment to {table_name}: {e}')
+            else:
+                self._logger.info(f'No table docstring found for {table_name}')
+
+            # Extract field-level comments from model source code
+            # Since Tortoise doesn't natively support field descriptions, we'll look for
+            # comments in the model definition using inspect
+            try:
+                source_lines = inspect.getsource(model_class).split('\n')
+                field_comments = {}
+
+                self._logger.info(f'Extracting field comments from {table_name}, {len(source_lines)} lines')
+
+                for i, line in enumerate(source_lines):
+                    line = line.strip()
+                    # Look for field definitions - check for both quoted and unquoted field references
+                    if (
+                        '=' in line
+                        and ('fields.' in line or "'fields." in line or '"fields.' in line)
+                        and not line.startswith('#')
+                    ):
+                        # Extract field name
+                        field_name = line.split('=')[0].strip()
+                        if field_name and not field_name.startswith('_'):
+                            # Look for comments above this line
+                            comment_lines = []
+                            j = i - 1
+                            while j >= 0:
+                                prev_line = source_lines[j].strip()
+                                if prev_line.startswith('#'):
+                                    comment_lines.insert(0, prev_line[1:].strip())
+                                    j -= 1
+                                elif prev_line == '':
+                                    j -= 1
+                                else:
+                                    break
+
+                            if comment_lines:
+                                field_comments[field_name] = ' '.join(comment_lines)
+                                self._logger.info(f'Found comment for field {field_name}: {field_comments[field_name]}')
+
+                self._logger.info(f'Found {len(field_comments)} field comments for {table_name}')
+
+                # Apply field comments
+                if hasattr(model_class._meta, 'fields_map'):
+                    self._logger.info(f'Processing {len(model_class._meta.fields_map)} fields for {table_name}')
+                    for field_name, _field in model_class._meta.fields_map.items():
+                        self._logger.info(f'Checking field: {field_name}')
+                        if field_name in field_comments:
+                            field_doc = field_comments[field_name].strip().replace("'", "''")
+                            if len(field_doc) > 1000:
+                                field_doc = field_doc[:997] + '...'
+
+                            # Get the actual database column name
+                            db_column = model_class._meta.fields_db_projection.get(field_name, field_name)
+
+                            try:
+                                sql = f"COMMENT ON COLUMN {self._database_config.schema_name}.{table_name}.{db_column} IS '{field_doc}';"
+                                self._logger.info(f'Executing column comment SQL: {sql}')
+                                await conn.execute_script(sql)
+                                self._logger.info(f'Successfully applied column comment to {table_name}.{db_column}')
+                            except Exception as e:
+                                self._logger.warning(f'Failed to apply column comment to {table_name}.{db_column}: {e}')
+                        else:
+                            self._logger.info(f'No comment found for field {field_name} in {table_name}')
+                else:
+                    self._logger.warning(f'No fields_map found for {table_name}')
+
+            except Exception as e:
+                self._logger.warning(f'Failed to extract field comments from {table_name}: {e}')
+
+        self._logger.info(f'Finished applying model comments to database. Processed {model_count} models.')

--- a/tests/test_model_comments.py
+++ b/tests/test_model_comments.py
@@ -1,0 +1,250 @@
+"""Tests for model comments functionality in Hasura integration."""
+
+import inspect
+
+import pytest
+
+from dipdup import fields
+from dipdup.config import HasuraConfig
+from dipdup.config import PostgresDatabaseConfig
+from dipdup.database import iter_models
+from dipdup.hasura import HasuraGateway
+from dipdup.models import Model
+
+
+class TestUser(Model):
+    """Represents a user in the system with authentication and profile information."""
+
+    id = fields.IntField(pk=True)
+
+    # The user's unique username for login
+    username = fields.CharField(max_length=50, unique=True)
+
+    # The user's email address for notifications
+    email = fields.CharField(max_length=255, unique=True)
+
+    # The user's full name for display
+    full_name = fields.CharField(max_length=100)
+
+    # When the user account was created
+    created_at = fields.DatetimeField(auto_now_add=True)
+
+    # Whether the user account is active
+    is_active = fields.BooleanField(default=True)
+
+    class Meta:
+        table = 'test_users'
+
+
+class TestProduct(Model):
+    """Represents a product in the marketplace."""
+
+    id = fields.IntField(pk=True)
+
+    # Product name
+    name = fields.CharField(max_length=200)
+
+    # Product description
+    description = fields.TextField()
+
+    # Product price in cents
+    price = fields.IntField()
+
+    class Meta:
+        table = 'test_products'
+
+
+def test_docstring_extraction() -> None:
+    """Test that class docstrings are properly extracted."""
+    table_doc = TestUser.__doc__ or ''
+    assert 'user in the system' in table_doc
+    assert 'authentication' in table_doc
+
+    table_doc = TestProduct.__doc__ or ''
+    assert 'product in the marketplace' in table_doc
+
+
+def test_field_comment_extraction() -> None:
+    """Test that field comments are properly extracted from source code."""
+    source_lines = inspect.getsource(TestUser).split('\n')
+    field_comments = {}
+
+    for i, line in enumerate(source_lines):
+        line = line.strip()
+        if '=' in line and ('fields.' in line or "'fields." in line or '"fields.' in line) and not line.startswith('#'):
+            field_name = line.split('=')[0].strip()
+            if field_name and not field_name.startswith('_'):
+                comment_lines = []
+                j = i - 1
+                while j >= 0:
+                    prev_line = source_lines[j].strip()
+                    if prev_line.startswith('#'):
+                        comment_lines.insert(0, prev_line[1:].strip())
+                        j -= 1
+                    elif prev_line == '':
+                        j -= 1
+                    else:
+                        break
+
+                if comment_lines:
+                    field_comments[field_name] = ' '.join(comment_lines)
+
+    # Verify specific field comments are extracted
+    assert 'username' in field_comments
+    assert 'unique username' in field_comments['username']
+    assert 'email' in field_comments
+    assert 'email address' in field_comments['email']
+    assert 'full_name' in field_comments
+    assert 'full name' in field_comments['full_name']
+
+
+def test_model_iteration() -> None:
+    """Test that models can be iterated properly."""
+    # This test would need to be run in a proper DipDup project context
+    # For now, we'll just verify the function exists
+    assert callable(iter_models)
+
+
+def test_hasura_gateway_methods() -> None:
+    """Test that HasuraGateway has the required methods for model comments."""
+    # Mock configs for testing
+    hasura_config = HasuraConfig(
+        url='http://localhost:8080',
+        source='default',
+        create_source=True,
+        rest=False,
+        camel_case=False,
+        allow_aggregations=False,
+        select_limit=100,
+        hide_internal=True,
+        hide=[],
+        allow_inconsistent_metadata=False,
+    )
+
+    database_config = PostgresDatabaseConfig(
+        kind='postgres',
+        host='localhost',
+        port=5432,
+        user='test',
+        password='test',
+        database='test',
+        schema_name='public',
+    )
+
+    # Create gateway instance
+    gateway = HasuraGateway(package='test_package', hasura_config=hasura_config, database_config=database_config)
+
+    # Verify required methods exist
+    assert hasattr(gateway, '_apply_model_comments')
+    assert hasattr(gateway, '_hasura_request')
+    assert hasattr(gateway, 'configure')
+
+    # Verify method is callable
+    assert callable(gateway._apply_model_comments)
+
+
+def test_comment_sql_generation() -> None:
+    """Test that SQL comments are generated correctly."""
+    table_name = 'test_users'
+    table_doc = 'Test table comment'
+    field_name = 'username'
+    field_doc = 'Test field comment'
+    schema_name = 'public'
+
+    # Test table comment SQL
+    table_sql = f"COMMENT ON TABLE {schema_name}.{table_name} IS '{table_doc}';"
+    assert 'COMMENT ON TABLE' in table_sql
+    assert table_name in table_sql
+    assert table_doc in table_sql
+
+    # Test column comment SQL
+    column_sql = f"COMMENT ON COLUMN {schema_name}.{table_name}.{field_name} IS '{field_doc}';"
+    assert 'COMMENT ON COLUMN' in column_sql
+    assert table_name in column_sql
+    assert field_name in column_sql
+    assert field_doc in column_sql
+
+
+def test_comment_length_limiting() -> None:
+    """Test that comments are properly limited in length."""
+    long_comment = 'x' * 2000  # Very long comment
+
+    # Simulate the limiting logic
+    if len(long_comment) > 1000:
+        limited_comment = long_comment[:997] + '...'
+
+    assert len(limited_comment) <= 1000
+    assert limited_comment.endswith('...')
+
+
+def test_comment_escaping() -> None:
+    """Test that single quotes in comments are properly escaped."""
+    comment_with_quotes = "This is a comment with 'single quotes'"
+    escaped_comment = comment_with_quotes.replace("'", "''")
+
+    assert "''" in escaped_comment
+    assert escaped_comment.count("'") == 4  # Two pairs of escaped quotes
+
+
+@pytest.mark.asyncio
+async def test_metadata_refresh_integration() -> None:
+    """Test that metadata refresh is properly integrated into the configure method."""
+    # This test verifies the integration without requiring a full Hasura setup
+
+    # Mock configs
+    hasura_config = HasuraConfig(
+        url='http://localhost:8080',
+        source='default',
+        create_source=True,
+        rest=False,
+        camel_case=False,
+        allow_aggregations=False,
+        select_limit=100,
+        hide_internal=True,
+        hide=[],
+        allow_inconsistent_metadata=False,
+    )
+
+    database_config = PostgresDatabaseConfig(
+        kind='postgres',
+        host='localhost',
+        port=5432,
+        user='test',
+        password='test',
+        database='test',
+        schema_name='public',
+    )
+
+    gateway = HasuraGateway(package='test_package', hasura_config=hasura_config, database_config=database_config)
+
+    # Verify the configure method source contains the required components
+    configure_source = inspect.getsource(gateway.configure)
+
+    # Check for model comments application
+    assert '_apply_model_comments' in configure_source
+
+    # Check for metadata refresh
+    assert 'reload_metadata' in configure_source
+
+    # Check for proper order (comments before refresh)
+    apply_comments_index = configure_source.find('_apply_model_comments')
+    reload_metadata_index = configure_source.find('reload_metadata')
+
+    assert apply_comments_index != -1
+    assert reload_metadata_index != -1
+    assert apply_comments_index < reload_metadata_index
+
+
+def test_model_meta_attributes() -> None:
+    """Test that model meta attributes are properly accessible."""
+    assert hasattr(TestUser, '_meta')
+    assert hasattr(TestUser._meta, 'db_table')
+    assert TestUser._meta.db_table == 'test_users'
+
+    assert hasattr(TestUser._meta, 'fields_map')
+    assert 'username' in TestUser._meta.fields_map
+    assert 'email' in TestUser._meta.fields_map
+
+    # Test fields_db_projection
+    if hasattr(TestUser._meta, 'fields_db_projection'):
+        assert 'username' in TestUser._meta.fields_db_projection


### PR DESCRIPTION
Hello,
I'm currently using dipdup with hasura for multiple products on prod.
Since dipdup automatically generate the Hasura GQL schema, there are currently no ways to edit the documentation per table and per fields for the generated schema without directly sending post requests to Hasura post-sync.

With this PR, I add the possibility for the users to add descriptions per table and per fields for their databases.
The solution works by automatically extracting Python docstrings from Tortoise ORM model classes and comments above field definitions, then applying them as PostgreSQL database comments that become visible in Hasura's GraphQL playground. 

For example, when you defining a model like this:
```
class EquiteezUser(Model):
    """Represents an Equiteez account tracked by the indexer."""

    id = fields.IntField(primary_key=True)

    # Public key hash of the User
    address = fields.CharField(max_length=36, index=True, unique=True)

    class Meta:
        table = 'equiteez_user'
```

The hasura playground will show this:
<img width="550" alt="image" src="https://github.com/user-attachments/assets/be0cd303-b3ee-42a1-8654-d1c67aeb5754" />

The class docstring becomes the table description, and the comments above each field become column descriptions that users will see when exploring the GraphQL schema in Hasura's playground.
The implementation integrates seamlessly with `dipdup hasura configure` and `dipdup run` (after the applying the schema), so there's no additional configuration needed. When you run the configure or the run command (at the beginning of the sync), it automatically extracts the documentation from your models, applies it to the database using PostgreSQL COMMENT statements, and refreshes Hasura's metadata to pick up the new comments. I had to force the refresh of the hasura metadata because it wouldn't apply the fields descriptions otherwise.
I also added a test file with this feature.

Have a nice day!