### PR TITLE
chore: Fix gauge semantics

### DIFF
--- a/src/dipdup/performance.py
+++ b/src/dipdup/performance.py
@@ -326,9 +326,10 @@ class _MetricManager:
         self._http_errors.labels(url=url, status=status).inc()
 
     def set_http_errors_in_row(self, url: str, errors_count: int) -> None:
-        self._http_errors_in_row.inc(errors_count)
+        # Gauge semantics: represent the current consecutive error count, not the delta
+        self._http_errors_in_row.set(errors_count)
         if 'subsquid' in url:
-            self._sqd_processor_archive_http_errors_in_row.inc(errors_count)
+            self._sqd_processor_archive_http_errors_in_row.set(errors_count)
 
     def stats(self) -> dict[str, Any]:
         def _round(value: Any) -> Any:


### PR DESCRIPTION
## Summary
Fixes Prometheus gauge semantics for consecutive HTTP error tracking.

## Problem
`set_http_errors_in_row()` used `inc(errors_count)` which accumulates values instead of representing the current consecutive error count.

## Solution
Changed to `set(errors_count)` to properly represent current consecutive error count as a Gauge metric.

## Impact
Prometheus metrics now correctly show current consecutive failure count instead of cumulative sum.