### PR TITLE
Fix spelling issues

### DIFF
--- a/src/demo_evm_uniswap/models/__init__.py
+++ b/src/demo_evm_uniswap/models/__init__.py
@@ -337,7 +337,7 @@ class Swap(Model):
     transaction_hash = fields.TextField()
     # timestamp of transaction
     timestamp = fields.DatetimeField(db_index=True)
-    # pool swap occured within
+    # pool swap occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='swaps')
     # allow indexing by tokens
     token0: fields.ForeignKeyRelation[Token] = fields.ForeignKeyField('models.Token', related_name='swaps_token0')
@@ -369,7 +369,7 @@ class Collect(Model):
     transaction_hash = fields.TextField()
     # timestamp of event
     timestamp = fields.BigIntField()
-    # pool collect occured within
+    # pool collect occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='collects')
     # owner of position collect was performed on
     owner = fields.CharField(max_length=42, null=True)
@@ -393,7 +393,7 @@ class Flash(Model):
     transaction_hash = fields.TextField()
     # timestamp of event
     timestamp = fields.BigIntField()
-    # pool collect occured within
+    # pool collect occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='flashed')
     # sender of the flash
     sender = fields.CharField(max_length=42)

--- a/src/dipdup/codegen/tezos.py
+++ b/src/dipdup/codegen/tezos.py
@@ -133,7 +133,7 @@ class TezosCodeGenerator(CodeGenerator):
             else:
                 pass
 
-        # NOTE: Euristics for complex cases like templated `similar_to` factories.
+        # NOTE: Heuristics for complex cases like templated `similar_to` factories.
         # NOTE: Try different contracts and datasources from config until one succeeds.
         for template_config in unused_operation_templates:
             self._logger.warning(

--- a/src/dipdup/config/__init__.py
+++ b/src/dipdup/config/__init__.py
@@ -1087,7 +1087,7 @@ class DipDupConfig(InteractiveMixin):
             if name in SYSTEM_HOOKS:
                 raise ConfigurationError(f'`{name}` hook name is reserved by system hook')
 
-        # NOTE: Rollback depth euristics and validation
+        # NOTE: Rollback depth heuristics and validation
         rollback_depth = 0
         for name, datasource_config in self.datasources.items():
             try:

--- a/src/dipdup/projects/demo_evm_uniswap/models/__init__.py.j2
+++ b/src/dipdup/projects/demo_evm_uniswap/models/__init__.py.j2
@@ -337,7 +337,7 @@ class Swap(Model):
     transaction_hash = fields.TextField()
     # timestamp of transaction
     timestamp = fields.DatetimeField(db_index=True)
-    # pool swap occured within
+    # pool swap occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='swaps')
     # allow indexing by tokens
     token0: fields.ForeignKeyRelation[Token] = fields.ForeignKeyField('models.Token', related_name='swaps_token0')
@@ -369,7 +369,7 @@ class Collect(Model):
     transaction_hash = fields.TextField()
     # timestamp of event
     timestamp = fields.BigIntField()
-    # pool collect occured within
+    # pool collect occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='collects')
     # owner of position collect was performed on
     owner = fields.CharField(max_length=42, null=True)
@@ -393,7 +393,7 @@ class Flash(Model):
     transaction_hash = fields.TextField()
     # timestamp of event
     timestamp = fields.BigIntField()
-    # pool collect occured within
+    # pool collect occurred within
     pool: fields.ForeignKeyRelation[Pool] = fields.ForeignKeyField('models.Pool', related_name='flashed')
     # sender of the flash
     sender = fields.CharField(max_length=42)

--- a/src/dipdup/sql/dipdup_wipe.sql
+++ b/src/dipdup/sql/dipdup_wipe.sql
@@ -1,5 +1,5 @@
 -- Drops all user-defined objects (views, materialized views, tables, sequences, types, functions, TimescaleDB hypertables/chunks) 
--- in the specified schema. A complete schema wipe without dropping the schema itself. Afair this was implemented for compatibility
+-- in the specified schema. A complete schema wipe without dropping the schema itself. Affair this was implemented for compatibility
 -- with some cloud providers.
 CREATE OR REPLACE FUNCTION dipdup_wipe(schema_name VARCHAR) RETURNS void AS $$
 DECLARE


### PR DESCRIPTION
Fixed a bunch of spelling typos in different files:
changing ‘occured’ to ‘occurred’ in several places,
fixing ‘euristics’ to ‘heuristics’ in the config note,
and also switching ‘Afair’ to ‘Affair’ in that SQL comment.