### PR TITLE
Batch expired record processing in tezos domains demo

### DIFF
--- a/src/demo_tezos_domains/hooks/check_expiration.py
+++ b/src/demo_tezos_domains/hooks/check_expiration.py
@@ -8,23 +8,39 @@ from dipdup.context import HookContext
 if TYPE_CHECKING:
     from dipdup.datasources.tezos_tzkt import TezosTzktDatasource
 
+BATCH_SIZE = 1000
+
 
 async def check_expiration(
     ctx: HookContext,
 ) -> None:
     ds = cast('TezosTzktDatasource', next(iter(ctx.datasources.values())))
-    expiring_records = (
-        await Record.filter(expired=False, domain__expires_at__lt=datetime.utcnow()).all().prefetch_related('domain')
-    )
+    total_processed = 0
 
-    for record in expiring_records:
-        ctx.logger.info('Record %s expired at %s', record.id, record.domain.expires_at)
-        record.expired = True
-        await record.save()
-        if record.address:
-            ctx.logger.debug('Invalidating contract metadata for %s @ %s', record.address, record.id)
-            await ctx.update_contract_metadata(
-                network=ds.name,
-                address=record.address,
-                metadata={},  # TODO: NULL
-            )
+    while True:
+        expiring_records = (
+            await Record.filter(expired=False, domain__expires_at__lt=datetime.utcnow())
+            .limit(BATCH_SIZE)
+            .prefetch_related('domain')
+        )
+
+        if not expiring_records:
+            break
+
+        for record in expiring_records:
+            ctx.logger.info('Record %s expired at %s', record.id, record.domain.expires_at)
+            record.expired = True
+            await record.save()
+            if record.address:
+                ctx.logger.debug('Invalidating contract metadata for %s @ %s', record.address, record.id)
+                await ctx.update_contract_metadata(
+                    network=ds.name,
+                    address=record.address,
+                    metadata={},  # TODO: NULL
+                )
+
+        total_processed += len(expiring_records)
+        ctx.logger.info('Processed %s expired records so far', total_processed)
+
+    if total_processed:
+        ctx.logger.info('Finished processing %s expired records', total_processed)

--- a/src/dipdup/projects/demo_tezos_domains/hooks/check_expiration.py.j2
+++ b/src/dipdup/projects/demo_tezos_domains/hooks/check_expiration.py.j2
@@ -1,27 +1,46 @@
 from datetime import datetime
+from typing import TYPE_CHECKING
 from typing import cast
 
 from {{ project.package }}.models import Record
 from dipdup.context import HookContext
-from dipdup.datasources.tezos_tzkt import TezosTzktDatasource
+
+if TYPE_CHECKING:
+    from dipdup.datasources.tezos_tzkt import TezosTzktDatasource
+
+BATCH_SIZE = 1000
 
 
 async def check_expiration(
     ctx: HookContext,
 ) -> None:
-    ds = cast(TezosTzktDatasource, next(iter(ctx.datasources.values())))
-    expiring_records = (
-        await Record.filter(expired=False, domain__expires_at__lt=datetime.utcnow()).all().prefetch_related('domain')
-    )
+    ds = cast('TezosTzktDatasource', next(iter(ctx.datasources.values())))
+    total_processed = 0
 
-    for record in expiring_records:
-        ctx.logger.info('Record %s expired at %s', record.id, record.domain.expires_at)
-        record.expired = True
-        await record.save()
-        if record.address:
-            ctx.logger.debug('Invalidating contract metadata for %s @ %s', record.address, record.id)
-            await ctx.update_contract_metadata(
-                network=ds.name,
-                address=record.address,
-                metadata={},  # TODO: NULL
-            )
+    while True:
+        expiring_records = (
+            await Record.filter(expired=False, domain__expires_at__lt=datetime.utcnow())
+            .limit(BATCH_SIZE)
+            .prefetch_related('domain')
+        )
+
+        if not expiring_records:
+            break
+
+        for record in expiring_records:
+            ctx.logger.info('Record %s expired at %s', record.id, record.domain.expires_at)
+            record.expired = True
+            await record.save()
+            if record.address:
+                ctx.logger.debug('Invalidating contract metadata for %s @ %s', record.address, record.id)
+                await ctx.update_contract_metadata(
+                    network=ds.name,
+                    address=record.address,
+                    metadata={},  # TODO: NULL
+                )
+
+        total_processed += len(expiring_records)
+        ctx.logger.info('Processed %s expired records so far', total_processed)
+
+    if total_processed:
+        ctx.logger.info('Finished processing %s expired records', total_processed)


### PR DESCRIPTION
## Summary
- Process expired records in batches of 1000 instead of loading all at once to avoid memory issues with large datasets
- Add progress logging for batch processing

🤖 Generated with [Claude Code](https://claude.com/claude-code)