### PR TITLE
fix: remove invalid duplicate path removal in _rm_demo

### DIFF
--- a/scripts/demos.py
+++ b/scripts/demos.py
@@ -53,7 +53,6 @@ def _init_demo(path: Path) -> None:
 
 def _rm_demo(path: Path) -> None:
     rmtree(path, ignore_errors=True)
-    rmtree(path.parent / 'src' / path.name, ignore_errors=True)
 
 
 @click.group(help='Various tools to generate demo projects from templates. Read the script source!')


### PR DESCRIPTION
_rm_demo had a redundant rmtree call that constructed an invalid path (.../src/src/demo_xxx), which never exists. It was always a silent no-op due to ignore_errors=True. Removed it.