### PR TITLE
fix: honor explicit sources in self install, explain non-uv-tool self update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 Releases prior to 7.0 has been removed from this file to declutter search results; see the [archived copy](https://github.com/dipdup-io/dipdup/blob/8.0.0b5/CHANGELOG.md) for the full list.
 
+## [Unreleased]
+
+### Fixed
+
+- cli: `dipdup self install` no longer silently does nothing when `--path`, `--ref` or `--pre` is passed and DipDup is already on `PATH`.
+- cli: `dipdup self update` now explains how to upgrade installations not managed by `uv tool`, instead of relaying uv's "`dipdup` is not installed".
+
 ## [8.6.0] - 2026-06-29
 
 ### Added

--- a/src/dipdup/install.py
+++ b/src/dipdup/install.py
@@ -131,6 +131,39 @@ def uninstall(quiet: bool) -> NoReturn:
     done('Done! DipDup is uninstalled.')
 
 
+def is_uv_tool(package: str) -> bool:
+    """Whether `package` is installed as a `uv tool` — the only kind `self update` can upgrade.
+
+    Determined from `uv tool dir`, which holds exactly one directory per installed tool. This is
+    more robust across uv versions than parsing `uv tool list` output or guessing from `$PATH`.
+    """
+    result = subprocess.run(
+        ('uv', 'tool', 'dir'),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return False
+    return (Path(result.stdout.strip()) / package).is_dir()
+
+
+def fail_not_uv_tool() -> NoReturn:
+    """Explain why `self update` can't proceed and how to update instead."""
+    dipdup_path = which('dipdup')
+    location = f' at `{dipdup_path}`' if dipdup_path else ''
+    echo(f'Found DipDup{location}, but it is not managed by `uv tool`.', Colors.RED)
+    echo(
+        '`dipdup self update` can only upgrade a `uv tool` installation. Update it the way it was installed:',
+        Colors.YELLOW,
+    )
+    print('    - project virtualenv:   uv pip install -U dipdup')
+    print('                            (or: uv sync --upgrade-package dipdup)')
+    print('    - pipx:                 pipx upgrade dipdup')
+    print('    - switch to uv tool:    uv tool install --force dipdup   # then `dipdup self update` will work')
+    sys.exit(1)
+
+
 def install(
     quiet: bool,
     force: bool,
@@ -158,27 +191,27 @@ def install(
     if editable:
         uv_tool_args.append('-e')
 
-    dipdup_path = which(
-        'dipdup',
-        path=os.environ['PATH'].replace('.venv', 'NULL'),
-    )
-
-    if dipdup_path is not None:
-        if version:
-            run_cmd('uv', 'tool', 'install', f'dipdup=={version}', *uv_tool_args)
-        elif update:
-            run_cmd('uv', 'tool', 'upgrade', 'dipdup', *uv_tool_args)
-    elif path:
+    # NOTE: Each branch maps to exactly one deterministic `uv` command. Order is by specificity:
+    # an explicit source (path/ref/version) wins; `update` upgrades an existing tool; else fresh install.
+    if path:
         echo(f'Installing DipDup from `{path}`')
         run_cmd('uv', 'tool', 'install', path, *uv_tool_args)
     elif ref:
         url = f'git+{GITHUB}@{ref}'
         echo(f'Installing DipDup from `{url}`')
         run_cmd('uv', 'tool', 'install', url, *uv_tool_args)
+    elif version:
+        echo(f'Installing DipDup {version}')
+        run_cmd('uv', 'tool', 'install', f'dipdup=={version}', *uv_tool_args)
+    elif update:
+        # NOTE: `uv tool upgrade` only works on a `uv tool` install; bail out with guidance otherwise.
+        if not is_uv_tool('dipdup'):
+            fail_not_uv_tool()
+        echo('Updating DipDup')
+        run_cmd('uv', 'tool', 'upgrade', 'dipdup', *uv_tool_args)
     else:
         echo('Installing DipDup from PyPI')
-        pkg = 'dipdup' if not version else f'dipdup=={version}'
-        run_cmd('uv', 'tool', 'install', pkg, *uv_tool_args)
+        run_cmd('uv', 'tool', 'install', 'dipdup', *uv_tool_args)
 
     done('Done! DipDup is ready to use. Run `dipdup` see available commands.')
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,87 @@
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from dipdup import install
+
+
+def test_is_uv_tool(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    (tmp_path / 'dipdup').mkdir()
+
+    def _uv_tool_dir(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        assert args[0] == ('uv', 'tool', 'dir')
+        return subprocess.CompletedProcess(args[0], 0, stdout=f'{tmp_path}\n', stderr='')
+
+    monkeypatch.setattr(subprocess, 'run', _uv_tool_dir)
+
+    assert install.is_uv_tool('dipdup') is True
+    assert install.is_uv_tool('not-installed') is False
+
+
+def test_is_uv_tool_without_uv(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _failed(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args[0], 2, stdout='', stderr='error')
+
+    monkeypatch.setattr(subprocess, 'run', _failed)
+
+    assert install.is_uv_tool('dipdup') is False
+
+
+def test_update_bails_out_when_not_uv_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(install, 'prepare', lambda: None)
+    monkeypatch.setattr(install, 'is_uv_tool', lambda _: False)
+    monkeypatch.setattr(install, 'run_cmd', lambda *args, **kwargs: commands.append(args))
+
+    with pytest.raises(SystemExit) as e:
+        install.install(quiet=True, force=False, version=None, ref=None, path=None, update=True)
+
+    assert e.value.code == 1
+    # NOTE: `uv tool upgrade` would have reported DipDup as not installed at all
+    assert not commands
+
+
+def test_update_upgrades_uv_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(install, 'prepare', lambda: None)
+    monkeypatch.setattr(install, 'is_uv_tool', lambda _: True)
+    monkeypatch.setattr(install, 'run_cmd', lambda *args, **kwargs: commands.append(args))
+
+    with pytest.raises(SystemExit) as e:
+        install.install(quiet=True, force=False, version=None, ref=None, path=None, update=True)
+
+    assert e.value.code == 0
+    assert commands == [('uv', 'tool', 'upgrade', 'dipdup')]
+
+
+@pytest.mark.parametrize(
+    ('kwargs', 'expected'),
+    (
+        ({}, ('uv', 'tool', 'install', 'dipdup')),
+        ({'version': '8.6.0'}, ('uv', 'tool', 'install', 'dipdup==8.6.0')),
+        ({'ref': 'next'}, ('uv', 'tool', 'install', f'git+{install.GITHUB}@next')),
+        ({'path': '.'}, ('uv', 'tool', 'install', '.')),
+        ({'force': True}, ('uv', 'tool', 'install', 'dipdup', '--force')),
+        ({'pre': True}, ('uv', 'tool', 'install', 'dipdup', '--prerelease', 'allow')),
+    ),
+)
+def test_install_sources(
+    kwargs: dict[str, Any],
+    expected: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[tuple[str, ...]] = []
+
+    monkeypatch.setattr(install, 'prepare', lambda: None)
+    # NOTE: DipDup is already on PATH; an explicit source must still be honored
+    monkeypatch.setattr(install, 'which', lambda *args, **kwargs: '/usr/local/bin/dipdup')
+    monkeypatch.setattr(install, 'run_cmd', lambda *args, **kwargs: commands.append(args))
+
+    with pytest.raises(SystemExit):
+        install.install(**{'quiet': True, 'force': False, 'version': None, 'ref': None, 'path': None, **kwargs})
+
+    assert commands == [expected]


### PR DESCRIPTION
## Summary

- `dipdup self install --path .` / `--ref <branch>` / `--pre` silently did nothing when DipDup was already on `PATH`: `install()` branched on `which('dipdup')` first, handled only `--version` and `update` inside that branch, and fell through to `Done!` without running any command. Branch selection now follows what was asked for — explicit source, then update, then fresh install — one `uv` command per branch.
- `dipdup self update` runs `uv tool upgrade`, which only works on a `uv tool` installation. For a virtualenv or pipx layout uv answers ``error: Failed to upgrade dipdup / Caused by: `dipdup` is not installed`` — which contradicts the working `dipdup` the user just invoked. The layout is now detected via `uv tool dir` and the command prints how to upgrade that installation instead.

## Tests

`tests/test_install.py` records the `uv` command line each entry point produces. Against the previous implementation 5 of the 6 source cases fail with no command recorded at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)