### PR TITLE
fix: bump datamodel-code-generator to 0.71.0 and regenerate demo types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 - context: `ctx.rollback` now reverts all model updates above `to_level` instead of stopping at `from_level`, which belongs to the datasource channel and can lag behind the index.
 - index: Rollbacks are no longer dropped when the affected levels are still queued as realtime messages; the decision is made when the index reaches the message.
 
+### Changed
+
+- codegen: Empty-object Michelson `unit` fields are now generated with `max_length=0`, so a non-empty object fails validation instead of being accepted.
+- codegen: Fields named after Python builtins are now suffixed and aliased (`bool` becomes `bool_: bool = Field(..., alias='bool')`); JSON parsing is unaffected, but attribute access in handlers must be updated after regenerating types.
+- codegen: Nullable required fields no longer get an implicit `= None` default, so constructing such models from Python now requires the argument explicitly.
+- codegen: Root models generated from non-nullable schemas no longer accept `None`.
+
+### Security
+
+- deps: `datamodel-code-generator` updated to 0.71.0, fixing 9 advisories affecting 0.28.5 — most notably arbitrary import injection into generated modules via the `x-python-import`/`customTypePath` schema keys ([GHSA-5578-w22f-pfx9](https://github.com/advisories/GHSA-5578-w22f-pfx9)), reachable because schemas are derived from remote ABIs and contract metadata.
+
 ## [8.6.0] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 
 - codegen: Empty-object Michelson `unit` fields are now generated with `max_length=0`, so a non-empty object fails validation instead of being accepted.
 - codegen: Fields named after Python builtins are now suffixed and aliased (`bool` becomes `bool_: bool = Field(..., alias='bool')`); JSON parsing is unaffected, but attribute access in handlers must be updated after regenerating types.
-- codegen: Nullable required fields no longer get an implicit `= None` default, so constructing such models from Python now requires the argument explicitly.
+- codegen: Nullable required fields no longer get an implicit `= None` default, so a payload that omits the key now fails validation instead of parsing as `None`; regenerate types and check handlers that read such fields.
 - codegen: Root models generated from non-nullable schemas no longer accept `None`.
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 - cli: `dipdup self install` no longer silently does nothing when `--path`, `--ref` or `--pre` is passed and DipDup is already on `PATH`.
 - cli: `dipdup self update` now explains how to upgrade installations not managed by `uv tool`, instead of relaying uv's "`dipdup` is not installed".
 - context: `ctx.rollback` now reverts all model updates above `to_level` instead of stopping at `from_level`, which belongs to the datasource channel and can lag behind the index.
+- evm.events: Fixed parsing nested tuples in event payloads when a field is named after a Python keyword (`from`); the lookup used a literal `{k}_ ` instead of the field name and always raised `KeyError`.
 - index: Rollbacks are no longer dropped when the affected levels are still queued as realtime messages; the decision is made when the index reaches the message.
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
     # NOTE: Pinned; bumping requires regenerating `src/demo_*/types` and reviewing the diff.
     # NOTE: Avoid 0.29-0.46: F821 Undefined name `bool_aliased` (#2431), fixed in 0.47.
     # NOTE: Avoid 0.57-0.61: invalid Python for our substrate TypedDict codegen (IndentationError).
+    # NOTE: Do not go below 0.64: earlier versions inject `x-python-import` schema keys verbatim (GHSA-5578-w22f-pfx9).
     "datamodel-code-generator==0.71.0", # pinned
     "debugpy>=1.8.15",
     "eth-abi~=5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,10 @@ dependencies = [
     "async-lru~=2.0",
     "asyncpg~=0.29",
     "click~=8.1",
-    # NOTE: Bug introduded 0.29: F821 Undefined name `bool_aliased` (#2431)
-    # NOTE: Fixed in 0.51.0, but it breaks our codegen.
-    "datamodel-code-generator==0.28.5", # pinned
+    # NOTE: Pinned; bumping requires regenerating `src/demo_*/types` and reviewing the diff.
+    # NOTE: Avoid 0.29-0.46: F821 Undefined name `bool_aliased` (#2431), fixed in 0.47.
+    # NOTE: Avoid 0.57-0.61: invalid Python for our substrate TypedDict codegen (IndentationError).
+    "datamodel-code-generator==0.71.0", # pinned
     "debugpy>=1.8.15",
     "eth-abi~=5.0",
     "lru-dict~=1.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -203,9 +203,9 @@ cytoolz==1.1.0 ; (implementation_name == 'cpython' and sys_platform == 'darwin')
     --hash=sha256:de425c5a8e3be7bb3a195e19191d28d9eb3c2038046064a92edc4505033ec9cb \
     --hash=sha256:e7e29a1a03f00b4322196cfe8e2c38da9a6c8d573566052c586df83aacc5663c
     # via eth-utils
-datamodel-code-generator==0.28.5 ; sys_platform == 'darwin' or sys_platform == 'linux' \
-    --hash=sha256:20e8b817d301d2d0bb15f436e81c97b25ad1c2ef922c99249c2444141ae15a6a \
-    --hash=sha256:f899c1da5af04b5d5b6e3edbd718c1bf3a00fc4b2fe8210cef609d93a9983e9e
+datamodel-code-generator==0.71.0 ; sys_platform == 'darwin' or sys_platform == 'linux' \
+    --hash=sha256:680b68338d59e98a0559eeb54d8e5ca33c35b3ec0bef922ec2cc783f2cb28e9a \
+    --hash=sha256:d27cd7a0d10f9b2db74a41db7f3e050c226da9cf0afb4916a7ab56275ebacbf2
     # via dipdup
 debugpy==1.8.21 ; sys_platform == 'darwin' or sys_platform == 'linux' \
     --hash=sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e \
@@ -469,7 +469,6 @@ packaging==26.2 ; sys_platform == 'darwin' or sys_platform == 'linux' \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
     # via
     #   black
-    #   datamodel-code-generator
     #   marshmallow
 parsimonious==0.10.0 ; sys_platform == 'darwin' or sys_platform == 'linux' \
     --hash=sha256:8281600da180ec8ae35427a4ab4f7b82bfec1e3d1e52f80cb60ea82b9512501c \

--- a/src/demo_substrate_events/types/assethub/substrate_events/assets_transferred/v601.py
+++ b/src/demo_substrate_events/types/assethub/substrate_events/assets_transferred/v601.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from typing import TypedDict
 
-"""
-Some assets were transferred. [asset_id, from, to, amount]
-"""
 V601 = TypedDict(
     'V601',
     {

--- a/src/demo_tezos_auction/types/tzcolors_auction/tezos_storage.py
+++ b/src/demo_tezos_auction/types/tzcolors_auction/tezos_storage.py
@@ -20,5 +20,5 @@ class TzcolorsAuctionStorage1(BaseModel):
     bidder: str
 
 
-class TzcolorsAuctionStorage(RootModel[dict[str, TzcolorsAuctionStorage1] | None]):
-    root: dict[str, TzcolorsAuctionStorage1] | None = None
+class TzcolorsAuctionStorage(RootModel[dict[str, TzcolorsAuctionStorage1]]):
+    root: dict[str, TzcolorsAuctionStorage1]

--- a/src/demo_tezos_dao/types/registry/tezos_storage.py
+++ b/src/demo_tezos_dao/types/registry/tezos_storage.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 
 class Key(BaseModel):
@@ -21,7 +22,7 @@ class Delegate(BaseModel):
         extra='forbid',
     )
     key: Key
-    value: dict[str, Any]
+    value: dict[str, Any] = Field(..., max_length=0)
 
 
 class FreezeHistory(BaseModel):
@@ -55,7 +56,7 @@ class Key1(BaseModel):
         extra='forbid',
     )
     address: str
-    bool: bool
+    bool_: bool = Field(..., alias='bool')
 
 
 class Voter(BaseModel):

--- a/src/demo_tezos_dex/types/fa2_token/tezos_storage.py
+++ b/src/demo_tezos_dex/types/fa2_token/tezos_storage.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 
 class Key(BaseModel):
@@ -38,7 +39,7 @@ class Operator(BaseModel):
         extra='forbid',
     )
     key: Key1
-    value: dict[str, Any]
+    value: dict[str, Any] = Field(..., max_length=0)
 
 
 class TokenMetadata(BaseModel):

--- a/src/demo_tezos_dex/types/quipu_fa12/tezos_storage.py
+++ b/src/demo_tezos_dex/types/quipu_fa12/tezos_storage.py
@@ -27,7 +27,7 @@ class Voters(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    candidate: str | None = None
+    candidate: str | None
     last_veto: str
     veto: str
     vote: str
@@ -38,8 +38,8 @@ class Storage(BaseModel):
         extra='forbid',
     )
     baker_validator: str
-    current_candidate: str | None = None
-    current_delegated: str | None = None
+    current_candidate: str | None
+    current_delegated: str | None
     last_update_time: str
     last_veto: str
     ledger: dict[str, Ledger]

--- a/src/demo_tezos_dex/types/quipu_fa2/tezos_storage.py
+++ b/src/demo_tezos_dex/types/quipu_fa2/tezos_storage.py
@@ -27,7 +27,7 @@ class Voters(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    candidate: str | None = None
+    candidate: str | None
     last_veto: str
     veto: str
     vote: str
@@ -38,8 +38,8 @@ class Storage(BaseModel):
         extra='forbid',
     )
     baker_validator: str
-    current_candidate: str | None = None
-    current_delegated: str | None = None
+    current_candidate: str | None
+    current_delegated: str | None
     last_update_time: str
     last_veto: str
     ledger: dict[str, Ledger]

--- a/src/demo_tezos_domains/types/name_registry/tezos_big_maps/store_records_value.py
+++ b/src/demo_tezos_domains/types/name_registry/tezos_big_maps/store_records_value.py
@@ -10,10 +10,10 @@ class StoreRecordsValue(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    address: str | None = None
+    address: str | None
     data: dict[str, str]
-    expiry_key: str | None = None
+    expiry_key: str | None
     internal_data: dict[str, str]
     level: str
     owner: str
-    tzip12_token_id: str | None = None
+    tzip12_token_id: str | None

--- a/src/demo_tezos_factories/types/factory/tezos_storage.py
+++ b/src/demo_tezos_factories/types/factory/tezos_storage.py
@@ -51,7 +51,7 @@ class Voters(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    candidate: str | None = None
+    candidate: str | None
     last_veto: str
     veto: str
     vote: str

--- a/src/demo_tezos_factories/types/token/tezos_storage.py
+++ b/src/demo_tezos_factories/types/token/tezos_storage.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 
 class Key(BaseModel):
@@ -38,7 +39,7 @@ class Operator(BaseModel):
         extra='forbid',
     )
     key: Key1
-    value: dict[str, Any]
+    value: dict[str, Any] = Field(..., max_length=0)
 
 
 class TokenMetadata(BaseModel):

--- a/src/demo_tezos_nft_marketplace/types/hen_objkts/tezos_storage.py
+++ b/src/demo_tezos_nft_marketplace/types/hen_objkts/tezos_storage.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 
 class Key(BaseModel):
@@ -38,7 +39,7 @@ class Operator(BaseModel):
         extra='forbid',
     )
     key: Key1
-    value: dict[str, Any]
+    value: dict[str, Any] = Field(..., max_length=0)
 
 
 class TokenMetadata(BaseModel):

--- a/src/demo_tezos_token/types/tzbtc/tezos_storage.py
+++ b/src/demo_tezos_token/types/tzbtc/tezos_storage.py
@@ -14,4 +14,4 @@ class TzbtcStorage(BaseModel):
     big_map: dict[str, str]
     lambda_: str = Field(..., alias='lambda')
     nat: str
-    bool: bool
+    bool_: bool = Field(..., alias='bool')

--- a/src/dipdup/codegen/__init__.py
+++ b/src/dipdup/codegen/__init__.py
@@ -205,14 +205,17 @@ class CodeGenerator(_BaseCodeGenerator, ABC):
 
         import datamodel_code_generator as dmcg
 
+        # NOTE: Not re-exported from the package root; import from the module it's defined in.
+        from datamodel_code_generator.enums import DataModelType
+
         class_name = self.get_typeclass_name(schema_path)
         self._logger.info('Generating type `%s`', class_name)
         output_path.parent.mkdir(parents=True, exist_ok=True)
         # TODO: make it configurable
         if 'substrate' in str(output_path):
-            model_type = dmcg.DataModelType.TypingTypedDict
+            model_type = DataModelType.TypingTypedDict
         else:
-            model_type = dmcg.DataModelType.PydanticV2BaseModel
+            model_type = DataModelType.PydanticV2BaseModel
         dmcg.generate(
             input_=schema_path,
             output=output_path,

--- a/src/dipdup/utils.py
+++ b/src/dipdup/utils.py
@@ -211,13 +211,13 @@ def parse_object(
         model_dict = dict(zip(model_keys, data, strict=True))
 
         if nested:
+            # NOTE: Keys above are aliases; fields named after reserved keywords are `from_` and friends
+            field_names = {field.alias or key: key for key, field in type_.model_fields.items()}
             for k, v in model_dict.items():
                 if not isinstance(v, list | tuple):
                     continue
 
-                # NOTE: Might be `from_` or other reserved keyword
-                field_k = '{k}_ ' if k not in type_.model_fields else k
-                nested_type = type_.model_fields[field_k].annotation
+                nested_type = type_.model_fields[field_names[k]].annotation
                 model_dict[k] = parse_object(nested_type, v, plain=True)  # type: ignore[arg-type]
 
         return type_(**model_dict)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -97,3 +97,23 @@ async def test_parse_object() -> None:
     map_ = parse_object(QwerStorage, [[{'R': {'a': 'b'}}, {'R': {}}], [{'L': 'test'}]])
     assert isinstance(map_.root[0][0], QwerStorageItem1)
     assert map_.root[0][0].R['a'] == 'b'
+
+
+async def test_parse_object_nested_reserved_keyword() -> None:
+    from pydantic import BaseModel
+    from pydantic import Field
+
+    class Inner(BaseModel):
+        token: str
+        amount: int
+
+    class Outer(BaseModel):
+        # NOTE: `from` is reserved, so codegen emits the field as `from_` with an alias
+        from_: Inner = Field(..., alias='from')
+        to: str
+
+    # NOTE: EVM payloads arrive positionally, inner tuples are parsed by the same rules
+    parsed = parse_object(Outer, [['KT1', 42], 'tz1'], plain=True, nested=True)
+    assert parsed.from_.token == 'KT1'
+    assert parsed.from_.amount == 42
+    assert parsed.to == 'tz1'

--- a/uv.lock
+++ b/uv.lock
@@ -440,7 +440,7 @@ wheels = [
 
 [[package]]
 name = "datamodel-code-generator"
-version = "0.28.5"
+version = "0.71.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "argcomplete", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -449,13 +449,12 @@ dependencies = [
     { name = "inflect", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "isort", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "jinja2", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/65/19/d9d922913b86e9df48bfd4f959f3b215cd16c9fd563b4d0b1b6b31d3703b/datamodel_code_generator-0.28.5.tar.gz", hash = "sha256:20e8b817d301d2d0bb15f436e81c97b25ad1c2ef922c99249c2444141ae15a6a", size = 444237, upload-time = "2025-03-24T17:36:33.471Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/f5/f4ce23d99503b147c9ec514dc995a96d3b4d2a3284252ad665f875a3145d/datamodel_code_generator-0.71.0.tar.gz", hash = "sha256:d27cd7a0d10f9b2db74a41db7f3e050c226da9cf0afb4916a7ab56275ebacbf2", size = 1684916, upload-time = "2026-07-24T15:32:04.334Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/af/fdb43505db1accf89c4551eacedd3bc756b7bf57b190b87c29c75fee2555/datamodel_code_generator-0.28.5-py3-none-any.whl", hash = "sha256:f899c1da5af04b5d5b6e3edbd718c1bf3a00fc4b2fe8210cef609d93a9983e9e", size = 117290, upload-time = "2025-03-24T17:36:31.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/4d/556cb290170f41b97ce50fd872e10a266f141d7a38352bb3071e4ae61f41/datamodel_code_generator-0.71.0-py3-none-any.whl", hash = "sha256:680b68338d59e98a0559eeb54d8e5ca33c35b3ec0bef922ec2cc783f2cb28e9a", size = 452379, upload-time = "2026-07-24T15:32:02.467Z" },
 ]
 
 [[package]]
@@ -559,7 +558,7 @@ requires-dist = [
     { name = "async-lru", specifier = "~=2.0" },
     { name = "asyncpg", specifier = "~=0.29" },
     { name = "click", specifier = "~=8.1" },
-    { name = "datamodel-code-generator", specifier = "==0.28.5" },
+    { name = "datamodel-code-generator", specifier = "==0.71.0" },
     { name = "debugpy", specifier = ">=1.8.15" },
     { name = "eth-abi", specifier = "~=5.0" },
     { name = "lru-dict", specifier = "~=1.3" },


### PR DESCRIPTION
## Summary

All open Dependabot alerts on this repository are for `datamodel-code-generator`, pinned at `0.28.5`. Nine advisories apply to that version; the one that matters here is [GHSA-5578-w22f-pfx9](https://github.com/advisories/GHSA-5578-w22f-pfx9) — `x-python-import` / `customTypePath` schema keys are emitted verbatim into the generated `import` statements. DipDup derives schemas from remote ABIs and contract metadata (Etherscan, TzKT, Subscan) and imports the generated modules at runtime, so a hostile schema means code execution in the user's package.

`0.64.0` is the security floor (lowest version with zero advisories). Pinned `0.71.0`: output is byte-identical from 0.62.0 upward across all 95 cached schemas, so the extra headroom costs nothing in diff size.

The old pin comment was also wrong on the facts — the `bool_aliased` F821 bug (#2431) was fixed in 0.47.0, not 0.51.0, and the band that actually breaks our substrate codegen is 0.57.0–0.61.0 (module-level indented docstring → `IndentationError`). The NOTE now names both bands and the security floor.

## Generated diff

11 files, 22 insertions, 21 deletions. Four upstream behaviour changes, each reflected in the changelog:

- `List`/`Dict` → `list`/`dict` (0.46.0)
- nullable-required fields lose the implicit `= None` — **a payload omitting the key now fails validation instead of parsing as `None`**
- fields named after builtins become `bool_: bool = Field(..., alias='bool')` — JSON parsing unaffected, attribute access in handlers is not
- empty-object Michelson `unit` fields gain `max_length=0`
- one root model narrows from `dict[...] | None` to `dict[...]`, matching its schema

All three EVM demos are byte-identical, which matters because `parse_object(plain=True)` maps EVM payloads positionally — any field reorder would silently mis-map values.

`src/dipdup/codegen/__init__.py` needed one import change: `DataModelType` is no longer re-exported from the package root.

## Verification

`make lint` clean (ruff + mypy, 221 files). Offline suite 247 passed / 3 skipped — the skips are the Substrate cases needing `ONFINALITY_API_KEY`, which is set in CI. `check-links` clean, nothing under `docs/` moved. `uv lock --check` and `uv sync --locked` pass; the only `==` churn in `requirements.txt` is dmcg and its own transitive deps.

Regeneration was also checked from a **cold schema cache**, in two arms run sequentially with `~/.local/share/dipdup/schemas/demo_*` purged before each: `next` at 0.28.5 and this branch at 0.71.0, 18 of 19 demos refetched over the network in both. `git status --porcelain src/` came back empty in both arms, so no upstream ABI or contract-schema drift is hiding in this diff — and diffing the two arms' outputs against each other reproduces exactly these 43 lines, which is also the proof that the two arms were really running different generator versions.

`demo_tezos_etherlink` is the one demo that could not be inited, in either arm: it points at `api.parisnet.tzkt.io`, a decommissioned testnet whose DNS no longer resolves, and `DipDup.init` enters every datasource context before consulting the cache. That is pre-existing on `next` and untouched here — this branch does not modify its types.

## Also in this PR

`parse_object(nested=True)` recovered the field behind an alias by building the name as `'{k}_ '` — a plain string, not an f-string, with a trailing space — so every nested EVM event field named after a reserved keyword raised `KeyError: '{k}_ '` instead of resolving to `from_`. The mapping now comes from the model. Unrelated to the bump; it surfaced while reviewing how generated aliases are consumed, and rides along rather than waiting for its own review.

## Follow-ups (not in this PR)

- 0.71.0 makes external formatters opt-in; codegen output is currently normalized by our own ruff pass, but that coupling is undocumented.
- A formatting failure is a warning, not an error, since 0.47.0 — codegen can write invalid Python and still exit 0.
- `use_schema_description=True` is inert with the current output model types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

