### PR TITLE
fix: config validation no longer invalidates itself; drop all buffered messages on reorg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog], and this project adheres to [Semantic
 
 Releases prior to 7.0 has been removed from this file to declutter search results; see the [archived copy](https://github.com/dipdup-io/dipdup/blob/8.0.0b5/CHANGELOG.md) for the full list.
 
+## [Unreleased]
+
+### Fixed
+
+- config: `buffer_size` no longer conflicts with the `advanced.rollback_depth` value that validation derives itself, which made the option unusable.
+- tezos.tzkt: All buffered messages of a rolled-back level are dropped; one message per level could survive the reorg and be processed later.
+
 ## [8.6.1] - 2026-08-03
 
 ### Fixed

--- a/src/dipdup/config/__init__.py
+++ b/src/dipdup/config/__init__.py
@@ -728,6 +728,9 @@ class DipDupConfig(InteractiveMixin):
         self._paths: list[Path] = []
         self._environment: dict[str, str] = {}
         self._json = DipDupYAMLConfig()
+        # NOTE: Validation writes the effective value back to `advanced.rollback_depth`; keep what
+        # NOTE: the user actually declared so a second `initialize()` doesn't mistake it for input.
+        self._declared_rollback_depth: int | None = self.advanced.rollback_depth
 
     @property
     def schema_name(self) -> str:
@@ -1097,7 +1100,7 @@ class DipDupConfig(InteractiveMixin):
 
             if not isinstance(datasource_config, TezosTzktDatasourceConfig):
                 continue
-            if datasource_config.buffer_size and self.advanced.rollback_depth:
+            if datasource_config.buffer_size and self._declared_rollback_depth:
                 raise ConfigurationError(
                     f'`{name}`: `buffer_size` option is incompatible with `advanced.rollback_depth`'
                 )

--- a/src/dipdup/datasources/tezos_tzkt.py
+++ b/src/dipdup/datasources/tezos_tzkt.py
@@ -191,9 +191,8 @@ class MessageBuffer:
             if level not in self._messages:
                 return False
 
-            for i, message in enumerate(self._messages[level]):
-                if message.type == type_:
-                    del self._messages[level][i]
+            # NOTE: Rebuild the list; deleting during iteration skips the message right after each match
+            self._messages[level] = [message for message in self._messages[level] if message.type != type_]
 
         return True
 

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -15,6 +15,7 @@ from dipdup.config.evm_transactions import EvmTransactionsHandlerConfig
 from dipdup.config.tezos import TezosContractConfig
 from dipdup.config.tezos_operations import TezosOperationsIndexConfig
 from dipdup.config.tezos_tzkt import TezosTzktDatasourceConfig
+from dipdup.exceptions import ConfigurationError
 from dipdup.models.tezos import TezosOperationType
 from dipdup.subscriptions.tezos_tzkt import HeadSubscription
 from dipdup.subscriptions.tezos_tzkt import OriginationSubscription
@@ -166,3 +167,25 @@ async def test_load_demo_config(demo_dipdup_config: Path) -> None:
 
 async def test_load_test_config(test_dipdup_config: Path) -> None:
     DipDupConfig.load([test_dipdup_config])
+
+
+async def test_rollback_depth_initialize_is_idempotent() -> None:
+    config = DipDupConfig.load([TEST_CONFIGS / 'dipdup.yaml'])
+    config.datasources['tzkt_mainnet'].buffer_size = 2  # type: ignore[union-attr]
+    assert config.advanced.rollback_depth is None
+
+    config.initialize()
+    assert config.advanced.rollback_depth == 2
+
+    # NOTE: The first pass writes the derived depth back; it must not read as user input
+    config.initialize()
+
+
+async def test_buffer_size_conflicts_with_declared_rollback_depth(tmp_path: Path) -> None:
+    overlay = tmp_path / 'overlay.yaml'
+    overlay.write_text('advanced:\n  rollback_depth: 5\n')
+    config = DipDupConfig.load([TEST_CONFIGS / 'dipdup.yaml', overlay])
+    config.datasources['tzkt_mainnet'].buffer_size = 2  # type: ignore[union-attr]
+
+    with pytest.raises(ConfigurationError):
+        config.initialize()

--- a/tests/test_datasources/test_tzkt_buffer.py
+++ b/tests/test_datasources/test_tzkt_buffer.py
@@ -57,3 +57,15 @@ async def test_rollback(buffer: MessageBuffer) -> None:
     assert buffer.rollback(TezosTzktMessageType.head, 3, 1) is True
     assert buffer.rollback(TezosTzktMessageType.operation, 1, 0) is False
     assert buffer.rollback(TezosTzktMessageType.head, 1, 0) is False
+
+
+async def test_rollback_drops_every_message_of_level(buffer: MessageBuffer) -> None:
+    # NOTE: TzKT splits operations of a single level into several messages
+    buffer.add(TezosTzktMessageType.operation, 2, [{'id': 1}])
+    buffer.add(TezosTzktMessageType.operation, 2, [{'id': 2}])
+    buffer.add(TezosTzktMessageType.head, 2, {})
+
+    assert buffer.rollback(TezosTzktMessageType.operation, 2, 1) is True
+
+    messages = [m for m in buffer._messages[2] if m.type == TezosTzktMessageType.operation]
+    assert messages == []


### PR DESCRIPTION
## Summary

Two bugs on the TzKT realtime path, both reachable only when `buffer_size` is set on a `tezos.tzkt` datasource. `generic-dex` runs pinned to this branch until it lands.

**Config validation was not idempotent.** `DipDupConfig.initialize()` derives `advanced.rollback_depth` from the datasources and writes it back into the config. A second call then sees a value the user never wrote and raises `` `buffer_size` option is incompatible with `advanced.rollback_depth` ``. Since `dipdup run` initializes the config twice — once in the CLI, once in the orchestrator — any project setting `buffer_size` crash-loops on startup. As `tezos.tzkt` defaults to `rollback_depth: 2`, this made the option unusable in practice. Validation now compares against the value declared in the config file.

**`MessageBuffer.rollback` dropped only part of a level.** It deleted from the list while iterating over it with `enumerate`, so the message right after each match was skipped. TzKT splits a level's operations across several messages, so a reorged level could keep one buffered message, which was then processed as if the reorg had never happened — silent data divergence with nothing in the logs.

## Tests

- `test_rollback_depth_initialize_is_idempotent` — a second `initialize()` on a config with `buffer_size` and no declared depth must not raise.
- `test_buffer_size_conflicts_with_declared_rollback_depth` — the incompatibility still fires when the depth really is declared.
- `test_rollback_drops_every_message_of_level` — two operation messages on one level, both dropped. The existing buffer tests use one message per type per level, which cannot catch this.

Both new tests fail on the current `next` and pass with the fix.

Draft until the pinned deployment has run on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)