### PR TITLE
fix: evm.node — emit a re-announced head once instead of crashing the emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 ### Fixed
 
 - config: `buffer_size` no longer conflicts with the `advanced.rollback_depth` value that validation derives itself, which made the option unusable.
+- evm.node: A project with both `evm.events` and `evm.transactions` indexes on one node datasource opens two `newHeads` subscriptions and gets every head announced twice; the second announcement no longer crashes the datasource with a `KeyError` and fires a phantom rollback.
 - tezos.tzkt: All buffered messages of a rolled-back level are dropped; one message per level could survive the reorg and be processed later.
 
 ## [8.6.1] - 2026-08-03

--- a/src/dipdup/datasources/evm_node.py
+++ b/src/dipdup/datasources/evm_node.py
@@ -290,10 +290,14 @@ class EvmNodeDatasource(JsonRpcDatasource[EvmNodeDatasourceConfig]):
     async def _handle_subscription(self, subscription: EvmNodeSubscription, data: Any) -> None:
         if isinstance(subscription, EvmNodeHeadSubscription):
             level_data = self._level_data[data['hash']]
+            # NOTE: Node can announce the same head more than once before the emitter drains
+            # the queue; both announcements share one LevelData, so queue it only once.
+            already_queued = level_data.head is not None
             level_data.head = data
             if subscription.transactions:
                 level_data.fetch_transactions = True
-            self._emitter_queue.put_nowait(level_data)
+            if not already_queued:
+                self._emitter_queue.put_nowait(level_data)
         elif isinstance(subscription, EvmNodeLogsSubscription):
             level_data = self._level_data[data['blockHash']]
             level_data.events.append(data)

--- a/tests/test_datasources/test_evm_node.py
+++ b/tests/test_datasources/test_evm_node.py
@@ -1,0 +1,146 @@
+import asyncio
+from typing import TYPE_CHECKING
+from typing import Any
+from unittest.mock import AsyncMock
+
+from dipdup.config.evm_node import EvmNodeDatasourceConfig
+from dipdup.datasources.evm_node import NODE_LEVEL_TIMEOUT
+from dipdup.datasources.evm_node import EvmNodeDatasource
+from dipdup.models import MessageType
+from dipdup.models.evm_node import EvmNodeHeadData
+from dipdup.subscriptions.evm_node import EvmNodeHeadSubscription
+
+if TYPE_CHECKING:
+    from dipdup.datasources import IndexDatasource
+
+# NOTE: A project with both an `evm.events` and an `evm.transactions` index on one node datasource
+# holds two unequal head subscriptions, so the node opens two identical `newHeads` streams and
+# announces every block twice, back to back. See `test_subscriptions.py` for the config side.
+PLAIN_HEAD = EvmNodeHeadSubscription()
+TRANSACTIONS_HEAD = EvmNodeHeadSubscription(transactions=True)
+
+# NOTE: A healthy emitter loop never returns; it parks on an empty queue. So "drain it" means
+# "run it until it stops making progress". Each queued head costs at most one `wait_level` sleep.
+DRAIN_TIMEOUT = max(1.0, NODE_LEVEL_TIMEOUT * 20)
+
+BLOCK_HASH = '0x' + 'ab' * 32
+
+
+def _head_json(block_hash: str, level: int) -> dict[str, Any]:
+    return {
+        'baseFeePerGas': '0x3b9aca00',
+        'difficulty': '0x0',
+        'extraData': '0x',
+        'gasLimit': '0x1c9c380',
+        'gasUsed': '0x5208',
+        'hash': block_hash,
+        'logsBloom': '0x' + '00' * 256,
+        'miner': '0x' + '00' * 20,
+        'mixHash': '0x' + '00' * 32,
+        'nonce': '0x0000000000000000',
+        'number': hex(level),
+        'parentHash': '0x' + '11' * 32,
+        'receiptsRoot': '0x' + '22' * 32,
+        'sha3Uncles': '0x' + '33' * 32,
+        'stateRoot': '0x' + '44' * 32,
+        'timestamp': hex(1_750_000_000 + level),
+        'transactionsRoot': '0x' + '55' * 32,
+    }
+
+
+class Recorder:
+    def __init__(self) -> None:
+        self.heads: list[int] = []
+        self.rollbacks: list[tuple[MessageType, int, int]] = []
+
+    def attach(self, datasource: EvmNodeDatasource) -> None:
+        async def on_head(_datasource: EvmNodeDatasource, head: EvmNodeHeadData) -> None:
+            self.heads.append(head.level)
+
+        async def on_rollback(
+            _datasource: 'IndexDatasource[Any]',
+            type_: MessageType,
+            from_level: int,
+            to_level: int,
+        ) -> None:
+            self.rollbacks.append((type_, from_level, to_level))
+
+        datasource.call_on_head(on_head)
+        datasource.call_on_rollback(on_rollback)
+
+
+def _node_datasource() -> tuple[EvmNodeDatasource, Recorder]:
+    # NOTE: Datasource is never started; the emitter only leaves the process to fetch a full block.
+    config = EvmNodeDatasourceConfig(kind='evm.node', url='http://localhost', ws_url='ws://localhost')
+    config._name = 'node'
+
+    datasource = EvmNodeDatasource(config)
+    datasource.get_block_by_level = AsyncMock(return_value={'transactions': []})  # type: ignore[method-assign]
+    recorder = Recorder()
+    recorder.attach(datasource)
+    return datasource, recorder
+
+
+async def _drain(datasource: EvmNodeDatasource) -> None:
+    try:
+        await asyncio.wait_for(datasource._emitter_loop(), timeout=DRAIN_TIMEOUT)
+    except TimeoutError:
+        pass
+
+
+async def test_head_is_emitted() -> None:
+    datasource, recorder = _node_datasource()
+
+    await datasource._handle_subscription(PLAIN_HEAD, _head_json(BLOCK_HASH, 42))
+    await _drain(datasource)
+
+    assert recorder.heads == [42]
+    assert recorder.rollbacks == []
+    assert dict(datasource._level_data) == {}
+
+
+async def test_distinct_heads_are_emitted() -> None:
+    datasource, recorder = _node_datasource()
+
+    await datasource._handle_subscription(PLAIN_HEAD, _head_json('0x' + 'a1' * 32, 42))
+    await datasource._handle_subscription(PLAIN_HEAD, _head_json('0x' + 'a2' * 32, 43))
+    await _drain(datasource)
+
+    assert recorder.heads == [42, 43]
+    assert recorder.rollbacks == []
+    assert dict(datasource._level_data) == {}
+
+
+async def test_head_from_two_subscriptions_is_emitted_once() -> None:
+    datasource, recorder = _node_datasource()
+
+    await datasource._handle_subscription(PLAIN_HEAD, _head_json(BLOCK_HASH, 42))
+    await datasource._handle_subscription(TRANSACTIONS_HEAD, _head_json(BLOCK_HASH, 42))
+    await _drain(datasource)
+
+    # NOTE: Emitting the second announcement would re-emit the head and, since its level is not
+    # greater than the known one, fire a rollback on every EVM channel — a phantom one-level reorg.
+    assert recorder.heads == [42]
+    assert recorder.rollbacks == []
+    assert dict(datasource._level_data) == {}
+    # NOTE: Folding the pair must not lose what the second announcement asked for.
+    datasource.get_block_by_level.assert_awaited_once_with(block_number=42, full_transactions=True)  # type: ignore[attr-defined]
+
+
+async def test_head_announced_again_during_emit_is_ignored() -> None:
+    datasource, recorder = _node_datasource()
+
+    # NOTE: `on_head` runs inside the emitter pass, after the queue item was taken but before the
+    # level data is dropped — the window a queue-membership check would miss.
+    async def announce_again(_datasource: EvmNodeDatasource, _head: EvmNodeHeadData) -> None:
+        await datasource._handle_subscription(TRANSACTIONS_HEAD, _head_json(BLOCK_HASH, 42))
+
+    datasource.call_on_head(announce_again)
+
+    await datasource._handle_subscription(PLAIN_HEAD, _head_json(BLOCK_HASH, 42))
+    await _drain(datasource)
+
+    assert recorder.heads == [42]
+    assert recorder.rollbacks == []
+    assert dict(datasource._level_data) == {}
+    datasource.get_block_by_level.assert_awaited_once_with(block_number=42, full_transactions=True)  # type: ignore[attr-defined]

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,4 +1,17 @@
+from dipdup.subscriptions.evm_node import EvmNodeHeadSubscription
 from dipdup.subscriptions.evm_node import EvmNodeLogsSubscription
+
+
+def test_head_subscriptions_differ_but_share_params() -> None:
+    # NOTE: `evm.events` indexes ask for `EvmNodeHeadSubscription()`, `evm.transactions` ones for
+    # `EvmNodeHeadSubscription(transactions=True)`. Both land in the same set (evm.node never
+    # merges subscriptions), and `transactions` never reaches the wire — so a project with both
+    # index kinds on one node datasource opens two identical `newHeads` streams and gets every
+    # head announced twice.
+    subscriptions = {EvmNodeHeadSubscription(), EvmNodeHeadSubscription(transactions=True)}
+
+    assert len(subscriptions) == 2
+    assert {tuple(s.get_params()) for s in subscriptions} == {('newHeads',)}
 
 
 def test_logs_subscription_omits_unset_filters() -> None:


### PR DESCRIPTION
## What breaks

`EvmNodeDatasource._emitter_loop` ends every pass with `del self._level_data[head.hash]`. `_handle_subscription` puts the *same* `LevelData` object on `_emitter_queue` on every `newHeads` frame, so when one hash is announced twice the queue holds two entries for one key. The second pass finds nothing to delete:

```
  File "dipdup/dipdup.py", line 778, in run
    await gather(*tasks)
  File "dipdup/dipdup.py", line 1021, in _event_wrapper
    await gather(*_run_tasks)
  File "dipdup/datasources/evm_node.py", line 103, in run
    await asyncio.gather(
  File "dipdup/datasources/evm_node.py", line 162, in _emitter_loop
    del self._level_data[head.hash]
        ~~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: '0xa1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1a1'
```

`defaultdict.__missing__` is wired to `__getitem__` only, so the delete behaves like a plain dict. Neither `gather` on the way out passes `return_exceptions`, so the KeyError unwinds out of `DipDup.run()` and ends the process. Under a supervisor that restarts it, this is a crash loop.

## The duplicate is ordinary traffic, not a broken node

`EvmNodeHeadSubscription` carries a `transactions` flag. `config/evm_events.py` requests `EvmNodeHeadSubscription()`; `config/evm_transactions.py` requests `EvmNodeHeadSubscription(transactions=True)`. Those are unequal frozen dataclass values, `SubscriptionManager` keys by value, and `EvmNodeDatasourceConfig.merge_subscriptions` is `False` — so a project with **both an `evm.events` and an `evm.transactions` index on one node datasource** opens two `eth_subscribe ["newHeads"]` channels on a single connection.

The node then correctly delivers every head once per subscription id. Observed against a live `octez-evm-node` — two `newHeads` subscriptions, one connection:

```
sub id 1 -> 0x5826499a5452be0d85d2a0787b4813bb
sub id 2 -> 0xa7642bd0a37b7948913cdf20ec02644d
head level=5683365 hash=0x56d7d19956a0 via sub#2
head level=5683365 hash=0x56d7d19956a0 via sub#1
head level=5683366 hash=0xcdfc1ccd8159 via sub#2
head level=5683366 hash=0xcdfc1ccd8159 via sub#1
```

Both frames land microseconds apart, far inside `NODE_LEVEL_TIMEOUT`, so both are queued before the emitter drains the first. The datasource dies on the first block after reaching realtime — deterministically, not intermittently.

Controls, so this is not misread as a node quirk: a *single* `newHeads` subscription held for five minutes against two different nodes produced 300 and 63 frames with zero repeated hashes, and re-subscribing on a fresh connection never re-announced an already-seen hash.

## Why tolerating the delete is not the fix

`pop(head.hash, None)` stops the crash and leaves the damage. The `del` is the *last* statement of the duplicate pass, so by the time it raises, the pass has already re-emitted the head and — because `head.level <= known_level` — fired `emit_rollback` on all four EVM channels. Downstream, `Index._rollback` does not skip (`to_level < state.level`), the `on_index_rollback` hook runs, `state.level` is rewound, and `_process_queue`'s `message_level <= state.level` dedupe is thereby defeated, so every handler for that block runs a second time. That is a phantom one-level reorg per duplicate head — silent, and worse to diagnose than the crash.

The added tests fail under `pop(...)` as well as under the current code, so they discriminate the two.

## The fix

Enqueue each `LevelData` at most once, which restores the invariant the existing `del` assumes — one queue entry per key, so each key is deleted exactly once by the pass that owns it. `_emitter_loop` is untouched.

The guard reads `level_data.head is not None` rather than queue membership on purpose: it also covers a duplicate arriving while the emitter is mid-pass, when the item is no longer pending but the key is still in `_level_data`. That window spans at least `NODE_LEVEL_TIMEOUT` plus the awaits in `emit_head` / `emit_events` / `get_block_by_level`, so it is not a corner case.

## Tests

`tests/test_datasources/test_evm_node.py`, offline — builds a datasource from a config that is never started, feeds `newHeads` frames into `_handle_subscription`, and runs the real `_emitter_loop` under a timeout:

- `test_head_is_emitted`, `test_distinct_heads_are_emitted` — controls; they pass before and after the change, proving the harness actually drives the loop.
- `test_duplicate_head_is_ignored` — back-to-back duplicate.
- `test_duplicate_head_during_emit_is_ignored` — duplicate delivered while the emitter is inside `on_head`.

Each asserts the observable contract (one head emitted, no rollback, no leftover level data) rather than "did not raise".

`ruff format`, `ruff check`, `mypy` over `src tests scripts` are clean; `pytest tests/test_datasources tests/test_reorg.py` → 49 passed. I did not run the full suite — it needs `ALCHEMY_API_KEY` / `ETHERSCAN_API_KEY` / `ONFINALITY_API_KEY`.

## An alternative you may prefer

Collapsing the two head subscriptions into one channel whose `transactions` flag is the OR across indexes would remove this source of duplicates at the root and halve the frames on the wire. It is a larger change to subscription management, and it would still leave the in-flight window open, so I kept this PR to the guard. Happy to follow up with that separately if it is the direction you want.
