### PR TITLE
docs: add missing docs publish step to release process

### DIFF
--- a/docs/14.contributing.md
+++ b/docs/14.contributing.md
@@ -146,7 +146,8 @@ Releasing a new version currently requires some manual actions:
 5. Commit and push all changes with a message like `Bump version X.Y.Z`. Open a PR and link it to the milestone.
 6. Optionally, temporary switch Docker images of hosted demos to the `aux-X.Y.Z` tag as a smoke test.
 7. Merge the PR, then `git tag X.Y.Z && git push origin X.Y.Z`. Wait for `release.yml` pipeline to finish.
-8. Announce the release on Twitter and Discord.
+8. Checkout the `X.Y.Z` tag and publish the docs (see [Publishing docs](#publishing-docs)).
+9. Announce the release on Twitter and Discord.
 
 This process should be automated in the future.
 


### PR DESCRIPTION
- Release process checklist skipped publishing docs entirely, so `docs.py`'s Publishing docs table existed but was never invoked as part of a release — dipdup.io stayed on the 8.5 docs through both the 8.6.0 and 8.6.1 releases.
- Add the missing step between tagging and the Twitter/Discord announcement, pointing at the existing Publishing docs table instead of duplicating it.
- The step spells out publishing from the release tag, not the working branch, since `make docs_publish` force-pushes the `docs` tag onto whatever commit is currently checked out.