### PR TITLE
fix: run docker tests on a linux runner and check pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 on:
+  # NOTE: `pull_request` is what gives fork PRs any checks at all; `push` covers the branches we merge into.
   push:
+    branches:
+      - 'next'
+      - 'unreleased'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/test.yml'
+  pull_request:
     paths:
       - 'src/**'
       - 'tests/**'
@@ -17,10 +28,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # NOTE: arm64 macos is the fastest runner. Full matrix is tested in `release.yml`.
+        # NOTE: arm64 macos is the fastest runner, but it has no Docker daemon; ubuntu runs the container
+        # NOTE: tests. Full matrix is tested in `release.yml`.
         include:
           - os: macos-15
             arch: arm64
+          - os: ubuntu-latest
+            arch: amd64
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 
 ### Fixed
 
-- ci: Pull requests are checked by the test workflow, including ones opened from forks.
-- ci: Tests requiring Docker are run on a Linux runner instead of being skipped.
 - config: `buffer_size` no longer conflicts with the `advanced.rollback_depth` value that validation derives itself, which made the option unusable.
 - tezos.tzkt: All buffered messages of a rolled-back level are dropped; one message per level could survive the reorg and be processed later.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Releases prior to 7.0 has been removed from this file to declutter search result
 
 ### Fixed
 
+- ci: Pull requests are checked by the test workflow, including ones opened from forks.
+- ci: Tests requiring Docker are run on a Linux runner instead of being skipped.
 - config: `buffer_size` no longer conflicts with the `advanced.rollback_depth` value that validation derives itself, which made the option unusable.
 - tezos.tzkt: All buffered messages of a rolled-back level are dropped; one message per level could survive the reorg and be processed later.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -11,6 +12,17 @@ env.set_test()
 
 
 TEST_CONFIGS = Path(__file__).parent / 'configs'
+
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def has_api_keys(*names: str) -> bool:
+    """Check that every API key is set to a non-empty value.
+
+    NOTE: GitHub exposes secrets unavailable to the job (e.g. on fork pull requests) as empty strings,
+    NOTE: so a bare presence check would send guarded tests to the network without credentials.
+    """
+    return all(os.environ.get(name) for name in names)
 
 
 @asynccontextmanager

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -1,4 +1,3 @@
-import os
 from collections.abc import Awaitable
 from collections.abc import Callable
 from contextlib import AsyncExitStack
@@ -16,6 +15,7 @@ from dipdup.test import run_in_tmp
 from dipdup.test import run_postgres_container
 from dipdup.test import tmp_project
 from tests import TEST_CONFIGS
+from tests import has_api_keys
 
 
 async def assert_run_token() -> None:
@@ -290,13 +290,13 @@ async def test_run_init(
 
     config_paths.append(TEST_CONFIGS / 'common_sqlite.yaml')
 
-    if 'evm' in config and not {'ALCHEMY_API_KEY', 'ETHERSCAN_API_KEY'} <= set(os.environ):
+    if 'evm' in config and not has_api_keys('ALCHEMY_API_KEY', 'ETHERSCAN_API_KEY'):
         pytest.skip('EVM tests require ALCHEMY_API_KEY and ETHERSCAN_API_KEY environment variables')
-    if 'starknet' in config and not {'ALCHEMY_API_KEY'} <= set(os.environ):
+    if 'starknet' in config and not has_api_keys('ALCHEMY_API_KEY'):
         pytest.skip('Starknet tests require ALCHEMY_API_KEY environment variable')
-    if 'substrate' in config and not {'ONFINALITY_API_KEY'} <= set(os.environ):
+    if 'substrate' in config and not has_api_keys('ONFINALITY_API_KEY'):
         pytest.skip('Substrate tests require ONFINALITY_API_KEY environment variable')
-    if 'substrate' in config and cmd == 'init' and not {'SUBSCAN_API_KEY'} <= set(os.environ):
+    if 'substrate' in config and cmd == 'init' and not has_api_keys('SUBSCAN_API_KEY'):
         pytest.skip('Substrate init tests require SUBSCAN_API_KEY environment variable')
     if (
         # NOTE: starknet demo is node-only (subsquid decommissioned its v2.archive dataset), so it needs no key here
@@ -304,7 +304,7 @@ async def test_run_init(
         and not config.endswith('_node')
         and 'portal' not in config
         and cmd == 'run'
-        and not {'SUBSQUID_API_KEY'} <= set(os.environ)
+        and not has_api_keys('SUBSQUID_API_KEY')
     ):
         pytest.skip(
             'Subsquid run tests require SUBSQUID_API_KEY environment variable (v2.archive gateways need a key since 2026-05-19)'
@@ -329,6 +329,15 @@ async def test_run_init(
             )
         )
         await assert_fn()
+
+
+async def test_skip_on_empty_api_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # NOTE: An unavailable secret arrives as an empty string, not as a missing variable.
+    monkeypatch.setenv('ALCHEMY_API_KEY', '')
+    monkeypatch.setenv('ETHERSCAN_API_KEY', '')
+
+    with pytest.raises(pytest.skip.Exception):
+        await test_run_init('demo_evm_events', 'demo_evm_events', 'init', None)
 
 
 async def test_run_dex_postgres() -> None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,23 @@
+from typing import Any
+from typing import cast
+
+from ruamel.yaml import YAML
+
+from tests import REPO_ROOT
+
+WORKFLOWS = REPO_ROOT / '.github' / 'workflows'
+
+
+def _load(name: str) -> dict[str, Any]:
+    return cast('dict[str, Any]', YAML(typ='safe').load((WORKFLOWS / name).read_text()))
+
+
+def test_pull_requests_are_checked() -> None:
+    # NOTE: `push` events of a fork PR fire in the fork, so without this trigger such PRs get no checks at all.
+    assert 'pull_request' in _load('test.yml')['on']
+
+
+def test_container_tests_have_a_runner() -> None:
+    # NOTE: macOS runners have no Docker daemon; without a Linux one the container tests are silently skipped.
+    matrix = _load('test.yml')['jobs']['test']['strategy']['matrix']['include']
+    assert any(entry['os'].startswith('ubuntu') for entry in matrix)


### PR DESCRIPTION
- `.github/workflows/test.yml` ran a single `macos-15`/arm64 matrix entry. macOS runners have no Docker daemon, so `get_docker_client()` raised `Skipped('Docker socket not found')` and the entire container suite silently disappeared from every run. Added a `ubuntu-latest`/amd64 entry alongside the macOS one.
- Every workflow was `on: push` only, so a fork PR's push event fires in the fork and upstream sees no checks at all (#1328 landed with an empty `statusCheckRollup`). Added a `pull_request` trigger to `test.yml` and narrowed `push` to `next`/`unreleased` so same-repo PRs aren't built twice.
- The API-key skip guards in `tests/test_demos.py` were membership tests (`{'ALCHEMY_API_KEY', ...} <= set(os.environ)`), but GitHub sets an unavailable secret to the empty string — the guarded tests ran unauthenticated and burned 1h27m in the HTTP retry loop. Replaced with a shared `has_api_keys()` in `tests/__init__.py` that requires a non-empty value.

Symptom: container tests pick host/container addresses by heuristic, and the PR job never runs them.
